### PR TITLE
Feat: Login 시, JWT 토큰 생성 및 DB 연동

### DIFF
--- a/src/main/java/com/chapter1/blueprint/exception/util/JsonResponseUtil.java
+++ b/src/main/java/com/chapter1/blueprint/exception/util/JsonResponseUtil.java
@@ -18,7 +18,6 @@ public class JsonResponseUtil {
 
     private final ObjectMapper objectMapper;
 
-    // 인증 실패 또는 접근 거부에 대한 JSON 응답을 생성하고 로그를 남김
     public void sendErrorResponse(HttpServletResponse response, HttpStatus status, String logMessage, String clientMessage) throws IOException {
         response.setStatus(status.value());
         response.setContentType("application/json");

--- a/src/main/java/com/chapter1/blueprint/member/domain/Member.java
+++ b/src/main/java/com/chapter1/blueprint/member/domain/Member.java
@@ -14,12 +14,11 @@ import java.time.LocalDateTime;
 public class Member {
     @Id
     @GeneratedValue
-
     @Column(name = "uid")
     private Long uid;
 
-    @Column(name = "id", length = 50, nullable = false)
-    private String id;
+    @Column(name = "member_id", length = 50, nullable = false)
+    private String memberId;
 
     @Column(length = 100, nullable = false)
     private String password;

--- a/src/main/java/com/chapter1/blueprint/member/dto/MemberDTO.java
+++ b/src/main/java/com/chapter1/blueprint/member/dto/MemberDTO.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class MemberDTO {
     private Long uid;
-    private String id;
+    private String memberId;
     private String password;
     private String memberName;
     private String email;

--- a/src/main/java/com/chapter1/blueprint/member/repository/MemberRepository.java
+++ b/src/main/java/com/chapter1/blueprint/member/repository/MemberRepository.java
@@ -9,5 +9,5 @@ import java.util.Optional;
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-    Optional<Member> findById(String id);
+    Optional<Member> findByMemberId(String memberId);
 }

--- a/src/main/java/com/chapter1/blueprint/member/service/MemberService.java
+++ b/src/main/java/com/chapter1/blueprint/member/service/MemberService.java
@@ -15,7 +15,7 @@ public class MemberService {
     // 회원 가입
     public String join(Member member) {
         memberRepository.save(member);
-        return member.getId();
+        return member.getMemberId();
     }
 
 }

--- a/src/main/java/com/chapter1/blueprint/security/config/SecurityConfig.java
+++ b/src/main/java/com/chapter1/blueprint/security/config/SecurityConfig.java
@@ -100,6 +100,7 @@ public class SecurityConfig {
 
     @Bean
     public PasswordEncoder passwordEncoder() {
+
         return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/java/com/chapter1/blueprint/security/controller/AuthController.java
+++ b/src/main/java/com/chapter1/blueprint/security/controller/AuthController.java
@@ -23,14 +23,14 @@ public class AuthController {
 
         String refreshToken = authDTO.getRefreshToken();
 
-        String id = jwtProcessor.getSubject(refreshToken);
+        String memberId = jwtProcessor.getSubject(refreshToken);
 
         if (jwtProcessor.validateRefreshToken(refreshToken)) {
-            Member member = memberRepository.findById(id)
+            Member member = memberRepository.findByMemberId(memberId)
                     .orElseThrow(() -> new RuntimeException("Invalid User"));
 
             String newAccessToken = jwtProcessor.generateAccessToken(
-                    member.getId(),
+                    member.getMemberId(),
                     member.getUid(),
                     member.getAuth(),
                     member.getMemberName(),
@@ -41,7 +41,7 @@ public class AuthController {
                     .accessToken(newAccessToken)
                     .refreshToken(refreshToken)
                     .uid(member.getUid())
-                    .id(member.getId())
+                    .memberId(member.getMemberId())
                     .memberName(member.getMemberName())
                     .email(member.getEmail())
                     .auth(member.getAuth())

--- a/src/main/java/com/chapter1/blueprint/security/dto/AuthDTO.java
+++ b/src/main/java/com/chapter1/blueprint/security/dto/AuthDTO.java
@@ -9,7 +9,7 @@ import lombok.Data;
 @Builder
 public class AuthDTO {
     private Long uid;
-    private String id;
+    private String memberId;
     private String memberName;
     private String email;
     private String accessToken;

--- a/src/main/java/com/chapter1/blueprint/security/dto/LoginDTO.java
+++ b/src/main/java/com/chapter1/blueprint/security/dto/LoginDTO.java
@@ -17,7 +17,7 @@ import java.io.IOException;
 @Builder
 public class LoginDTO {
 
-    private String id;
+    private String memberId;
     private String password;
     private String accessToken;
     private String refreshToken;

--- a/src/main/java/com/chapter1/blueprint/security/filter/JwtUsernamePasswordAuthenticationFilter.java
+++ b/src/main/java/com/chapter1/blueprint/security/filter/JwtUsernamePasswordAuthenticationFilter.java
@@ -45,43 +45,29 @@ public class JwtUsernamePasswordAuthenticationFilter extends UsernamePasswordAut
     @Override
     public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response)
             throws AuthenticationException {
-        try {
-            // LoginDTO null 체크
-            LoginDTO login = LoginDTO.of(request, objectMapper);
-            if (login == null || login.getMemberId() == null) {
-                throw new UsernameNotFoundException("로그인 정보가 올바르지 않습니다.");
-            }
 
-            // 로그인 시도 횟수 체크
-            int attempts = loginFailureHandler.getAttemptsCache().getOrDefault(login.getMemberId(), 0);
-            if (attempts >= LoginFailureHandler.getMAX_ATTEMPTS()) {
-                throw new BadCredentialsException("로그인 시도가 초과되었습니다.");
-            }
+        LoginDTO login = LoginDTO.of(request, objectMapper);
+        log.info("login: {}", login);
+        log.info("login getMemberId: {}", login.getMemberId());
+        Member member = memberRepository.findByMemberId(login.getMemberId())
+                .orElseThrow(() -> new UsernameNotFoundException("존재하지 않는 아이디입니다."));
 
-            // Member 조회 및 null 체크
-            Member member = memberRepository.findByMemberId(login.getMemberId())
-                    .orElseThrow(() -> new UsernameNotFoundException("존재하지 않는 아이디입니다."));
+        request.setAttribute("memberId", member.getMemberId());
+        log.info("request getMemberId: {}", login.getMemberId());
 
-            // Member 로그인 잠금 상태 체크
-            if (member.getIsLoginLocked() != null && member.getIsLoginLocked()) {
-                throw new BadCredentialsException("계정이 잠겨있습니다. 관리자에게 문의하세요.");
-            }
-
-            // 요청 속성 설정
-            request.setAttribute("memberId", member.getMemberId());
-
-            // 디버그 로깅
-            log.debug("Attempting authentication for ID: {}", login.getMemberId());
-
-            // 인증 토큰 생성 및 인증 시도
-            UsernamePasswordAuthenticationToken authenticationToken =
-                    new UsernamePasswordAuthenticationToken(login.getMemberId(), login.getPassword());
-
-            return getAuthenticationManager().authenticate(authenticationToken);
-
-        } catch (Exception e) {
-            log.error("Authentication attempt failed", e);
-            throw new AuthenticationException("인증 처리 중 오류가 발생했습니다: " + e.getMessage()) {};
+        int attempts = loginFailureHandler.getAttemptsCache().getOrDefault(login.getMemberId(), 0);
+        if (attempts >= LoginFailureHandler.getMAX_ATTEMPTS()) {
+            throw new BadCredentialsException("로그인 시도가 초과되었습니다.");
         }
+
+        log.info("Attempting authentication for ID: {}", login.getMemberId());
+        log.info("Password: {}", login.getPassword());
+
+        UsernamePasswordAuthenticationToken authenticationToken =
+                new UsernamePasswordAuthenticationToken(login.getMemberId(), login.getPassword());
+
+
+
+        return getAuthenticationManager().authenticate(authenticationToken);
     }
 }

--- a/src/main/java/com/chapter1/blueprint/security/filter/JwtUsernamePasswordAuthenticationFilter.java
+++ b/src/main/java/com/chapter1/blueprint/security/filter/JwtUsernamePasswordAuthenticationFilter.java
@@ -45,21 +45,43 @@ public class JwtUsernamePasswordAuthenticationFilter extends UsernamePasswordAut
     @Override
     public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response)
             throws AuthenticationException {
+        try {
+            // LoginDTO null 체크
+            LoginDTO login = LoginDTO.of(request, objectMapper);
+            if (login == null || login.getMemberId() == null) {
+                throw new UsernameNotFoundException("로그인 정보가 올바르지 않습니다.");
+            }
 
-        LoginDTO login = LoginDTO.of(request, objectMapper);
-        Member member = memberRepository.findById(login.getId())
-                .orElseThrow(() -> new UsernameNotFoundException("존재하지 않는 아이디입니다."));
+            // 로그인 시도 횟수 체크
+            int attempts = loginFailureHandler.getAttemptsCache().getOrDefault(login.getMemberId(), 0);
+            if (attempts >= LoginFailureHandler.getMAX_ATTEMPTS()) {
+                throw new BadCredentialsException("로그인 시도가 초과되었습니다.");
+            }
 
-        request.setAttribute("Id", member.getId());
+            // Member 조회 및 null 체크
+            Member member = memberRepository.findByMemberId(login.getMemberId())
+                    .orElseThrow(() -> new UsernameNotFoundException("존재하지 않는 아이디입니다."));
 
-        int attempts = loginFailureHandler.getAttemptsCache().getOrDefault(login.getId(), 0);
-        if (attempts >= LoginFailureHandler.getMAX_ATTEMPTS()) {
-            throw new BadCredentialsException("로그인 시도가 초과되었습니다.");
+            // Member 로그인 잠금 상태 체크
+            if (member.getIsLoginLocked() != null && member.getIsLoginLocked()) {
+                throw new BadCredentialsException("계정이 잠겨있습니다. 관리자에게 문의하세요.");
+            }
+
+            // 요청 속성 설정
+            request.setAttribute("memberId", member.getMemberId());
+
+            // 디버그 로깅
+            log.debug("Attempting authentication for ID: {}", login.getMemberId());
+
+            // 인증 토큰 생성 및 인증 시도
+            UsernamePasswordAuthenticationToken authenticationToken =
+                    new UsernamePasswordAuthenticationToken(login.getMemberId(), login.getPassword());
+
+            return getAuthenticationManager().authenticate(authenticationToken);
+
+        } catch (Exception e) {
+            log.error("Authentication attempt failed", e);
+            throw new AuthenticationException("인증 처리 중 오류가 발생했습니다: " + e.getMessage()) {};
         }
-
-        UsernamePasswordAuthenticationToken authenticationToken =
-                new UsernamePasswordAuthenticationToken(login.getId(), login.getPassword());
-
-        return getAuthenticationManager().authenticate(authenticationToken);
     }
 }

--- a/src/main/java/com/chapter1/blueprint/security/handle/LoginFailureHandler.java
+++ b/src/main/java/com/chapter1/blueprint/security/handle/LoginFailureHandler.java
@@ -37,6 +37,8 @@ public class LoginFailureHandler implements AuthenticationFailureHandler {
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
                                         AuthenticationException exception) throws IOException {
         String memberId = request.getParameter("memberId");
+        log.debug("Received memberId in onAuthenticationFailure: {}", memberId);
+
         Member member = memberRepository.findByMemberId(memberId)
                 .orElse(null);
 

--- a/src/main/java/com/chapter1/blueprint/security/handle/LoginFailureHandler.java
+++ b/src/main/java/com/chapter1/blueprint/security/handle/LoginFailureHandler.java
@@ -36,8 +36,8 @@ public class LoginFailureHandler implements AuthenticationFailureHandler {
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
                                         AuthenticationException exception) throws IOException {
-        String id = request.getParameter("id");
-        Member member = memberRepository.findById(id)
+        String memberId = request.getParameter("memberId");
+        Member member = memberRepository.findByMemberId(memberId)
                 .orElse(null);
 
         if (exception instanceof BadCredentialsException && member == null) {
@@ -55,12 +55,12 @@ public class LoginFailureHandler implements AuthenticationFailureHandler {
                 member.setIsLoginLocked(false);
                 member.setLoginLockTime(null);
                 memberRepository.save(member);
-                attemptsCache.put(id, 0);
+                attemptsCache.put(memberId, 0);
             }
         }
 
-        int attempts = attemptsCache.getOrDefault(id, 0) + 1;
-        attemptsCache.put(id, attempts);
+        int attempts = attemptsCache.getOrDefault(memberId, 0) + 1;
+        attemptsCache.put(memberId, attempts);
 
         if (attempts >= MAX_ATTEMPTS) {
             member.setIsLoginLocked(true);

--- a/src/main/java/com/chapter1/blueprint/security/handle/LoginSuccessHandler.java
+++ b/src/main/java/com/chapter1/blueprint/security/handle/LoginSuccessHandler.java
@@ -16,6 +16,8 @@ import org.springframework.security.web.authentication.AuthenticationSuccessHand
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.sql.Timestamp;
+import java.util.Date;
 import java.util.Optional;
 
 @Slf4j
@@ -36,6 +38,11 @@ public class LoginSuccessHandler implements AuthenticationSuccessHandler {
 
         String accessToken = jwtProcessor.generateAccessToken(memberId, uid, auth, memberName, email);
         String refreshToken = jwtProcessor.generateRefreshToken(memberId);
+        Timestamp expiration = jwtProcessor.getRefreshTokenExpiration();
+
+        member.setRefreshToken(refreshToken);
+        member.setExpiration(expiration);
+        memberRepository.save(member);
 
         return AuthDTO.builder()
                 .uid(uid)

--- a/src/main/java/com/chapter1/blueprint/security/handle/LoginSuccessHandler.java
+++ b/src/main/java/com/chapter1/blueprint/security/handle/LoginSuccessHandler.java
@@ -29,17 +29,17 @@ public class LoginSuccessHandler implements AuthenticationSuccessHandler {
 
     private AuthDTO makeAuth(Member member) {
         Long uid = member.getUid();
-        String id = member.getId();
+        String memberId = member.getMemberId();
         String memberName = member.getMemberName();
         String email = member.getEmail();
         String auth = member.getAuth();
 
-        String accessToken = jwtProcessor.generateAccessToken(id, uid, auth, memberName, email);
-        String refreshToken = jwtProcessor.generateRefreshToken(id);
+        String accessToken = jwtProcessor.generateAccessToken(memberId, uid, auth, memberName, email);
+        String refreshToken = jwtProcessor.generateRefreshToken(memberId);
 
         return AuthDTO.builder()
                 .uid(uid)
-                .id(id)
+                .memberId(memberId)
                 .memberName(memberName)
                 .email(email)
                 .accessToken(accessToken)
@@ -53,9 +53,9 @@ public class LoginSuccessHandler implements AuthenticationSuccessHandler {
                                         Authentication authentication) throws IOException, ServletException {
 
         UserDetails userDetails = (UserDetails) authentication.getPrincipal();
-        String id = userDetails.getUsername();
+        String memberId = userDetails.getUsername();
 
-        Optional<Member> memberOptional = memberRepository.findById(id);
+        Optional<Member> memberOptional = memberRepository.findByMemberId(memberId);
         if (memberOptional.isEmpty()) {
             response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "존재하지 않는 사용자입니다.");
             return;

--- a/src/main/java/com/chapter1/blueprint/security/service/CustomUserDetailsService.java
+++ b/src/main/java/com/chapter1/blueprint/security/service/CustomUserDetailsService.java
@@ -23,7 +23,7 @@ public class CustomUserDetailsService implements UserDetailsService {
 
         return User.withUsername(member.getMemberId())
                 .password(member.getPassword())
-                .roles(member.getAuth())
+                .authorities(member.getAuth())
                 .build();
     }
 }

--- a/src/main/java/com/chapter1/blueprint/security/service/CustomUserDetailsService.java
+++ b/src/main/java/com/chapter1/blueprint/security/service/CustomUserDetailsService.java
@@ -16,12 +16,12 @@ public class CustomUserDetailsService implements UserDetailsService {
     private final MemberRepository memberRepository;
 
     @Override
-    public UserDetails loadUserByUsername(String id) throws UsernameNotFoundException {
+    public UserDetails loadUserByUsername(String memberId) throws UsernameNotFoundException {
 
-        Member member = memberRepository.findById(id)
-                .orElseThrow(() -> new UsernameNotFoundException("User not found with id: " + id));
+        Member member = memberRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found with id: " + memberId));
 
-        return User.withUsername(member.getId())
+        return User.withUsername(member.getMemberId())
                 .password(member.getPassword())
                 .roles(member.getAuth())
                 .build();

--- a/src/main/java/com/chapter1/blueprint/security/util/JwtProcessor.java
+++ b/src/main/java/com/chapter1/blueprint/security/util/JwtProcessor.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Component;
 
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
+import java.sql.Timestamp;
 import java.util.Date;
 
 @Slf4j
@@ -59,13 +60,19 @@ public class JwtProcessor {
     }
 
     public String generateRefreshToken(String id) {
+        Timestamp expirationTimestamp = new Timestamp(new Date().getTime() + REFRESH_TOKEN_VALID_MILLISECONDS);
+
         return Jwts.builder()
                 .setSubject(id)
                 .claim("tokenType", "REFRESH")
                 .setIssuedAt(new Date())
-                .setExpiration(new Date(new Date().getTime() + REFRESH_TOKEN_VALID_MILLISECONDS))
+                .setExpiration(expirationTimestamp)
                 .signWith(key)
                 .compact();
+    }
+
+    public Timestamp getRefreshTokenExpiration() {
+        return new Timestamp(new Date().getTime() + REFRESH_TOKEN_VALID_MILLISECONDS);
     }
 
     private Claims parseTokenClaims(String token) {

--- a/src/test/java/com/chapter1/blueprint/security/config/PasswordEncryptionTest.java
+++ b/src/test/java/com/chapter1/blueprint/security/config/PasswordEncryptionTest.java
@@ -1,0 +1,41 @@
+package com.chapter1.blueprint.security.config;
+
+import com.chapter1.blueprint.member.domain.Member;
+import com.chapter1.blueprint.member.repository.MemberRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.sql.Timestamp;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+public class PasswordEncryptionTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Test
+    public void testEncryptAndSavePassword() {
+        String memberId = "tester01";
+
+        Member member = memberRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("Member not found"));
+
+        String rawPassword = "1234*";
+        String encodedPassword = passwordEncoder.encode(rawPassword);
+
+        member.setPassword(encodedPassword);
+        member.setExpiration(new Timestamp(System.currentTimeMillis()));
+
+        memberRepository.save(member);
+
+        Member updatedMember = memberRepository.findByMemberId(memberId).get();
+        assertTrue(passwordEncoder.matches(rawPassword, updatedMember.getPassword()));
+    }
+}


### PR DESCRIPTION
### #️⃣ 24.11.03

### 📝 작업 내용
1. JWT 토큰 생성 및 데이터베이스 연동
   - `LoginSuccessHandler`에서 로그인 성공 시 refreshToken과 expiration timestamp를 생성하고, 이를 `Member` 엔티티에 저장하도록 변경
   - `JwtProcessor`의 `generateRefreshToken` 메서드에서 refreshToken의 만료 시간을 `Timestamp`로 생성하도록 수정

2. 테스트 코드를 통한 패스워드 암호화 적용
   - 기존 데이터베이스에 저장된 평문 패스워드를 `BCryptPasswordEncoder`로 암호화하여 저장할 수 있도록 테스트 코드를 작성
   - `BCryptPasswordEncoder`를 사용하여 데이터베이스에 저장된 비밀번호가 BCrypt 형식으로 암호화되도록 구현

3. 로그인 실패 처리 개선
   - `LoginFailureHandler`에서 `memberId` 값이 제대로 전달되지 않는 문제를 해결하기 위해 로깅을 활용해 디버깅
   - `JsonResponseUtil` 클래스에서 `memberId`가 제대로 전달되지 않으면 사용자에게 적절한 오류 메시지를 반환하도록 개선

### 스크린샷
![image](https://github.com/user-attachments/assets/824b550d-0270-40a6-afe1-855a76efb546)
- 포스트맨 Login test 성공
