### PR TITLE
Feat: 비밀번호 변경 API 구현

### DIFF
--- a/src/main/java/com/chapter1/blueprint/member/controller/MemberController.java
+++ b/src/main/java/com/chapter1/blueprint/member/controller/MemberController.java
@@ -3,6 +3,7 @@ package com.chapter1.blueprint.member.controller;
 import com.chapter1.blueprint.exception.dto.SuccessResponse;
 import com.chapter1.blueprint.member.domain.dto.InputProfileDTO;
 import com.chapter1.blueprint.member.domain.dto.FindPasswordDTO;
+import com.chapter1.blueprint.member.domain.dto.PasswordDTO;
 import com.chapter1.blueprint.member.domain.dto.ProfileInfoDTO;
 import com.chapter1.blueprint.member.dto.MemberDTO;
 import com.chapter1.blueprint.member.service.MemberService;
@@ -78,6 +79,15 @@ public class MemberController {
 
         memberService.updateMemberProfile(authenticatedUserId, inputProfileDTO);
         return ResponseEntity.ok(new SuccessResponse("업데이트 성공"));
+    }
+
+    @PostMapping("/verification/password")
+    public ResponseEntity<SuccessResponse> verifyPassword(@RequestBody PasswordDTO passwordDTO) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String authenticatedUserId = authentication.getName();
+
+        boolean result = memberService.verifyPassword(authenticatedUserId, passwordDTO);
+        return ResponseEntity.ok(new SuccessResponse(result));
     }
 
     //@GetMapping(value = "/members/new")

--- a/src/main/java/com/chapter1/blueprint/member/controller/MemberController.java
+++ b/src/main/java/com/chapter1/blueprint/member/controller/MemberController.java
@@ -66,28 +66,37 @@ public class MemberController {
     @GetMapping("/mypage")
     public ResponseEntity<SuccessResponse> getInfoMyPage() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        String authenticatedUserId = authentication.getName();
+        String authenticatedMemberId = authentication.getName();
 
-        ProfileInfoDTO profileInfoDTO = memberService.getInfoProfile(authenticatedUserId);
+        ProfileInfoDTO profileInfoDTO = memberService.getInfoProfile(authenticatedMemberId);
         return ResponseEntity.ok(new SuccessResponse(profileInfoDTO));
     }
 
     @PostMapping("/mypage")
     public ResponseEntity<SuccessResponse> updateMyPage(@RequestBody InputProfileDTO inputProfileDTO) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        String authenticatedUserId = authentication.getName();
+        String authenticatedMemberId = authentication.getName();
 
-        memberService.updateMemberProfile(authenticatedUserId, inputProfileDTO);
+        memberService.updateMemberProfile(authenticatedMemberId, inputProfileDTO);
         return ResponseEntity.ok(new SuccessResponse("업데이트 성공"));
     }
 
     @PostMapping("/verification/password")
     public ResponseEntity<SuccessResponse> verifyPassword(@RequestBody PasswordDTO passwordDTO) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        String authenticatedUserId = authentication.getName();
+        String authenticatedMemberId = authentication.getName();
 
-        boolean result = memberService.verifyPassword(authenticatedUserId, passwordDTO);
+        boolean result = memberService.verifyPassword(authenticatedMemberId, passwordDTO);
         return ResponseEntity.ok(new SuccessResponse(result));
+    }
+
+    @PostMapping("/change/password")
+    public ResponseEntity<SuccessResponse> updatePassword(@RequestBody PasswordDTO passwordDTO) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String authenticatedMemberId = authentication.getName();
+
+        memberService.updatePassword(authenticatedMemberId, passwordDTO);
+        return ResponseEntity.ok(new SuccessResponse("비밀번호 변경 성공"));
     }
 
     //@GetMapping(value = "/members/new")

--- a/src/main/java/com/chapter1/blueprint/member/domain/dto/PasswordDTO.java
+++ b/src/main/java/com/chapter1/blueprint/member/domain/dto/PasswordDTO.java
@@ -1,0 +1,10 @@
+package com.chapter1.blueprint.member.domain.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PasswordDTO {
+    private String password;
+}

--- a/src/main/java/com/chapter1/blueprint/member/repository/MemberRepository.java
+++ b/src/main/java/com/chapter1/blueprint/member/repository/MemberRepository.java
@@ -2,6 +2,8 @@ package com.chapter1.blueprint.member.repository;
 
 import com.chapter1.blueprint.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -15,5 +17,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     boolean existsByMemberId(String memberId);
     boolean existsByEmail(String email);
+
+    @Query("SELECT m.password FROM Member m WHERE m.memberId = :memberId")
+    String findPasswordByMemberId(@Param("memberId") String memberId);
 
 }

--- a/src/main/java/com/chapter1/blueprint/member/service/MemberService.java
+++ b/src/main/java/com/chapter1/blueprint/member/service/MemberService.java
@@ -3,11 +3,11 @@ import com.chapter1.blueprint.exception.codes.ErrorCode;
 import com.chapter1.blueprint.exception.codes.ErrorCodeException;
 import com.chapter1.blueprint.member.domain.Member;
 import com.chapter1.blueprint.member.domain.dto.InputProfileDTO;
+import com.chapter1.blueprint.member.domain.dto.PasswordDTO;
 import com.chapter1.blueprint.member.domain.dto.ProfileInfoDTO;
 import com.chapter1.blueprint.member.dto.MemberDTO;
 import com.chapter1.blueprint.member.repository.MemberRepository;
 import com.chapter1.blueprint.security.util.JwtProcessor;
-import jakarta.mail.MessagingException;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -121,7 +121,6 @@ public class MemberService {
     }
 
     // 마이페이지에서 추가 사항 입력 시 db 업데이트 (db변경 시 자동으로 update 해줌)
-    // 그래서 save 메소드 필요없음
     public void updateMemberProfile(String memberId, InputProfileDTO inputProfileDTO) {
         Member memberProfile = memberRepository.findByMemberId(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("Member not found with ID (InputProfile): " + memberId));
@@ -151,6 +150,11 @@ public class MemberService {
         profileInfoDTO.setHousingType(memberProfileInfo.getHousingType());
 
         return profileInfoDTO;
+    }
+
+    public boolean verifyPassword(String memberId, PasswordDTO passwordDTO) {
+        String password = memberRepository.findPasswordByMemberId(memberId);
+        return passwordEncoder.matches(passwordDTO.getPassword(), password);
     }
 
 }

--- a/src/main/java/com/chapter1/blueprint/member/service/MemberService.java
+++ b/src/main/java/com/chapter1/blueprint/member/service/MemberService.java
@@ -157,4 +157,13 @@ public class MemberService {
         return passwordEncoder.matches(passwordDTO.getPassword(), password);
     }
 
+    public void updatePassword(String memberId, PasswordDTO passwordDTO) {
+        String encodedPassword = passwordEncoder.encode(passwordDTO.getPassword());
+        Member member = memberRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new RuntimeException("Member not found with ID (ProfileInfo): " + memberId));
+
+        member.setPassword(encodedPassword);
+        memberRepository.save(member);
+    }
+
 }


### PR DESCRIPTION
### #️⃣ 24.11.08

### 📝 작업 내용
- 사용자의 비밀번호 일치 여부 API 구현
   - passwordEncoder.matches 메소드를 활용해서 인코딩된 비밀번호와 입력한 비밀번호 비교 
- 사용자의 비밀번호 변경 API 구현
- user를 member로 통일