### PR TITLE
Feat: 정책 필터링 API 구현 & Fix: 거주지 상세정보 API 수정

### DIFF
--- a/src/main/java/com/chapter1/blueprint/member/controller/MemberController.java
+++ b/src/main/java/com/chapter1/blueprint/member/controller/MemberController.java
@@ -99,6 +99,7 @@ public class MemberController {
         return ResponseEntity.ok(new SuccessResponse("비밀번호 변경 성공"));
     }
 
+
     //@GetMapping(value = "/members/new")
     //public String createForm() {
     //    return "members/createMemberForm";

--- a/src/main/java/com/chapter1/blueprint/member/domain/Member.java
+++ b/src/main/java/com/chapter1/blueprint/member/domain/Member.java
@@ -65,8 +65,14 @@ public class Member {
     @Column(name = "occupation")
     private String occupation;
 
-    @Column(name = "residence")
-    private String residence;
+    @Column(name = "region")
+    private String region;
+
+    @Column(name = "district")
+    private String district;
+
+    @Column(name = "local")
+    private String local;
 
     @Column(name = "marital_status")
     private Integer maritalStatus;

--- a/src/main/java/com/chapter1/blueprint/member/domain/dto/InputProfileDTO.java
+++ b/src/main/java/com/chapter1/blueprint/member/domain/dto/InputProfileDTO.java
@@ -9,6 +9,8 @@ public class InputProfileDTO {
     private Double income;
     private String occupation;
     private String region;
+    private String district;
+    private String local;
     private Integer maritalStatus;
     private Integer hasChildren;
     private String housingType;

--- a/src/main/java/com/chapter1/blueprint/member/domain/dto/InputProfileDTO.java
+++ b/src/main/java/com/chapter1/blueprint/member/domain/dto/InputProfileDTO.java
@@ -8,7 +8,7 @@ import lombok.Setter;
 public class InputProfileDTO {
     private Double income;
     private String occupation;
-    private String residence;
+    private String region;
     private Integer maritalStatus;
     private Integer hasChildren;
     private String housingType;

--- a/src/main/java/com/chapter1/blueprint/member/domain/dto/ProfileInfoDTO.java
+++ b/src/main/java/com/chapter1/blueprint/member/domain/dto/ProfileInfoDTO.java
@@ -11,6 +11,8 @@ public class ProfileInfoDTO {
     private Double income;
     private String occupation;
     private String region;
+    private String district;
+    private String local;
     private Integer maritalStatus;
     private Integer hasChildren;
     private String housingType;

--- a/src/main/java/com/chapter1/blueprint/member/domain/dto/ProfileInfoDTO.java
+++ b/src/main/java/com/chapter1/blueprint/member/domain/dto/ProfileInfoDTO.java
@@ -10,7 +10,7 @@ public class ProfileInfoDTO {
     private String email;
     private Double income;
     private String occupation;
-    private String residence;
+    private String region;
     private Integer maritalStatus;
     private Integer hasChildren;
     private String housingType;

--- a/src/main/java/com/chapter1/blueprint/member/repository/MemberRepository.java
+++ b/src/main/java/com/chapter1/blueprint/member/repository/MemberRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository

--- a/src/main/java/com/chapter1/blueprint/member/service/MemberService.java
+++ b/src/main/java/com/chapter1/blueprint/member/service/MemberService.java
@@ -127,7 +127,7 @@ public class MemberService {
 
         memberProfile.setIncome(inputProfileDTO.getIncome());
         memberProfile.setOccupation(inputProfileDTO.getOccupation());
-        memberProfile.setResidence(inputProfileDTO.getResidence());
+        memberProfile.setRegion(inputProfileDTO.getRegion());
         memberProfile.setMaritalStatus(inputProfileDTO.getMaritalStatus());
         memberProfile.setHasChildren(inputProfileDTO.getHasChildren());
         memberProfile.setHousingType(inputProfileDTO.getHousingType());
@@ -144,7 +144,7 @@ public class MemberService {
         profileInfoDTO.setEmail(memberProfileInfo.getEmail());
         profileInfoDTO.setIncome(memberProfileInfo.getIncome());
         profileInfoDTO.setOccupation(memberProfileInfo.getOccupation());
-        profileInfoDTO.setResidence(memberProfileInfo.getResidence());
+        profileInfoDTO.setResidence(memberProfileInfo.getRegion());
         profileInfoDTO.setMaritalStatus(memberProfileInfo.getMaritalStatus());
         profileInfoDTO.setHasChildren(memberProfileInfo.getHasChildren());
         profileInfoDTO.setHousingType(memberProfileInfo.getHousingType());

--- a/src/main/java/com/chapter1/blueprint/member/service/MemberService.java
+++ b/src/main/java/com/chapter1/blueprint/member/service/MemberService.java
@@ -144,7 +144,7 @@ public class MemberService {
         profileInfoDTO.setEmail(memberProfileInfo.getEmail());
         profileInfoDTO.setIncome(memberProfileInfo.getIncome());
         profileInfoDTO.setOccupation(memberProfileInfo.getOccupation());
-        profileInfoDTO.setResidence(memberProfileInfo.getRegion());
+        profileInfoDTO.setRegion(memberProfileInfo.getRegion());
         profileInfoDTO.setMaritalStatus(memberProfileInfo.getMaritalStatus());
         profileInfoDTO.setHasChildren(memberProfileInfo.getHasChildren());
         profileInfoDTO.setHousingType(memberProfileInfo.getHousingType());

--- a/src/main/java/com/chapter1/blueprint/member/service/MemberService.java
+++ b/src/main/java/com/chapter1/blueprint/member/service/MemberService.java
@@ -128,6 +128,8 @@ public class MemberService {
         memberProfile.setIncome(inputProfileDTO.getIncome());
         memberProfile.setOccupation(inputProfileDTO.getOccupation());
         memberProfile.setRegion(inputProfileDTO.getRegion());
+        memberProfile.setDistrict(inputProfileDTO.getDistrict());
+        memberProfile.setLocal(inputProfileDTO.getLocal());
         memberProfile.setMaritalStatus(inputProfileDTO.getMaritalStatus());
         memberProfile.setHasChildren(inputProfileDTO.getHasChildren());
         memberProfile.setHousingType(inputProfileDTO.getHousingType());
@@ -145,6 +147,8 @@ public class MemberService {
         profileInfoDTO.setIncome(memberProfileInfo.getIncome());
         profileInfoDTO.setOccupation(memberProfileInfo.getOccupation());
         profileInfoDTO.setRegion(memberProfileInfo.getRegion());
+        profileInfoDTO.setDistrict(memberProfileInfo.getDistrict());
+        profileInfoDTO.setLocal(memberProfileInfo.getLocal());
         profileInfoDTO.setMaritalStatus(memberProfileInfo.getMaritalStatus());
         profileInfoDTO.setHasChildren(memberProfileInfo.getHasChildren());
         profileInfoDTO.setHousingType(memberProfileInfo.getHousingType());

--- a/src/main/java/com/chapter1/blueprint/policy/controller/PolicyController.java
+++ b/src/main/java/com/chapter1/blueprint/policy/controller/PolicyController.java
@@ -1,6 +1,8 @@
 package com.chapter1.blueprint.policy.controller;
 
 import com.chapter1.blueprint.exception.dto.SuccessResponse;
+import com.chapter1.blueprint.policy.domain.PolicyList;
+import com.chapter1.blueprint.policy.domain.dto.FilterDTO;
 import com.chapter1.blueprint.policy.domain.dto.PolicyDetailDTO;
 import com.chapter1.blueprint.policy.domain.dto.PolicyListDTO;
 import com.chapter1.blueprint.policy.service.PolicyDetailService;
@@ -8,10 +10,7 @@ import com.chapter1.blueprint.policy.service.PolicyService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -40,5 +39,11 @@ public class PolicyController {
     public ResponseEntity<SuccessResponse> getPolicyDetail(@PathVariable Long idx) {
         PolicyDetailDTO policyDetailDTO = policyDetailService.getPolicyDetail(idx);
         return ResponseEntity.ok(new SuccessResponse(policyDetailDTO));
+    }
+
+    @PostMapping("/filter")
+    public ResponseEntity<SuccessResponse> getPolicyListByFiltering(@RequestBody FilterDTO filterDTO) {
+        List<PolicyList> policyListByFiltering = policyDetailService.getPolicyListByFiltering(filterDTO);
+        return ResponseEntity.ok(new SuccessResponse(policyListByFiltering));
     }
 }

--- a/src/main/java/com/chapter1/blueprint/policy/controller/PolicyController.java
+++ b/src/main/java/com/chapter1/blueprint/policy/controller/PolicyController.java
@@ -29,11 +29,11 @@ public class PolicyController {
         return ResponseEntity.ok(new SuccessResponse(result));
     }
 
-    @GetMapping("/list")
-    public ResponseEntity<SuccessResponse> getPolicyList() {
-        List<PolicyListDTO> policyList = policyDetailService.getPolicyList();
-        return ResponseEntity.ok(new SuccessResponse(policyList));
-    }
+//    @GetMapping("/list")
+//    public ResponseEntity<SuccessResponse> getPolicyList() {
+//        List<PolicyListDTO> policyList = policyDetailService.getPolicyList();
+//        return ResponseEntity.ok(new SuccessResponse(policyList));
+//    }
 
     @GetMapping("/detail/{idx}")
     public ResponseEntity<SuccessResponse> getPolicyDetail(@PathVariable Long idx) {

--- a/src/main/java/com/chapter1/blueprint/policy/domain/dto/FilterDTO.java
+++ b/src/main/java/com/chapter1/blueprint/policy/domain/dto/FilterDTO.java
@@ -6,6 +6,7 @@ import lombok.Setter;
 @Getter
 @Setter
 public class FilterDTO {
+    private String city;
     private String district;
     private String type;
 }

--- a/src/main/java/com/chapter1/blueprint/policy/domain/dto/FilterDTO.java
+++ b/src/main/java/com/chapter1/blueprint/policy/domain/dto/FilterDTO.java
@@ -1,0 +1,11 @@
+package com.chapter1.blueprint.policy.domain.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class FilterDTO {
+    private String district;
+    private String type;
+}

--- a/src/main/java/com/chapter1/blueprint/policy/repository/PolicyListRepository.java
+++ b/src/main/java/com/chapter1/blueprint/policy/repository/PolicyListRepository.java
@@ -1,10 +1,20 @@
 package com.chapter1.blueprint.policy.repository;
 
+import com.chapter1.blueprint.policy.domain.dto.FilterDTO;
 import org.springframework.data.jpa.repository.JpaRepository;
 import com.chapter1.blueprint.policy.domain.PolicyList;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface PolicyListRepository extends JpaRepository<PolicyList,Long> {
+
+    @Query("SELECT p FROM PolicyList p " +
+            "WHERE (:district IS NULL OR p.district = :district) " +
+            "AND (:type IS NULL OR p.type = :type)")
+    List<PolicyList> findByDistrictAndType(@Param("district") String district, @Param("type")String type);
 
 }

--- a/src/main/java/com/chapter1/blueprint/policy/repository/PolicyListRepository.java
+++ b/src/main/java/com/chapter1/blueprint/policy/repository/PolicyListRepository.java
@@ -1,6 +1,5 @@
 package com.chapter1.blueprint.policy.repository;
 
-import com.chapter1.blueprint.policy.domain.dto.FilterDTO;
 import org.springframework.data.jpa.repository.JpaRepository;
 import com.chapter1.blueprint.policy.domain.PolicyList;
 import org.springframework.data.jpa.repository.Query;
@@ -14,7 +13,8 @@ public interface PolicyListRepository extends JpaRepository<PolicyList,Long> {
 
     @Query("SELECT p FROM PolicyList p " +
             "WHERE (:district IS NULL OR p.district = :district) " +
-            "AND (:type IS NULL OR p.type = :type)")
-    List<PolicyList> findByDistrictAndType(@Param("district") String district, @Param("type")String type);
+            "AND (:type IS NULL OR p.type = :type) " +
+            "AND (:city IS NULL OR p.city = :city)")
+    List<PolicyList> findByDistrictAndType(@Param("city") String city, @Param("district") String district, @Param("type") String type);
 
 }

--- a/src/main/java/com/chapter1/blueprint/policy/service/PolicyDetailService.java
+++ b/src/main/java/com/chapter1/blueprint/policy/service/PolicyDetailService.java
@@ -2,6 +2,7 @@ package com.chapter1.blueprint.policy.service;
 
 import com.chapter1.blueprint.policy.domain.PolicyDetail;
 import com.chapter1.blueprint.policy.domain.PolicyList;
+import com.chapter1.blueprint.policy.domain.dto.FilterDTO;
 import com.chapter1.blueprint.policy.domain.dto.PolicyDetailDTO;
 import com.chapter1.blueprint.policy.domain.dto.PolicyListDTO;
 import com.chapter1.blueprint.policy.repository.PolicyListRepository;
@@ -11,7 +12,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.chapter1.blueprint.policy.repository.PolicyDetailRepository;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -57,5 +57,9 @@ public class PolicyDetailService {
         policyDetailDTO.setUrl(policyDetail.getUrl());
 
         return policyDetailDTO;
+    }
+
+    public List<PolicyList> getPolicyListByFiltering(FilterDTO filterDTO) {
+         return policyListRepository.findByDistrictAndType(filterDTO.getDistrict(), filterDTO.getType());
     }
 }

--- a/src/main/java/com/chapter1/blueprint/policy/service/PolicyDetailService.java
+++ b/src/main/java/com/chapter1/blueprint/policy/service/PolicyDetailService.java
@@ -22,25 +22,25 @@ public class PolicyDetailService {
     private final PolicyDetailRepository policyDetailRepository;
     private final PolicyListRepository policyListRepository;
 
-    public List<PolicyListDTO> getPolicyList() {
-        List<PolicyList> policyList = policyListRepository.findAll();
-
-        return policyList.stream().map(policy -> {
-            PolicyListDTO policyListDTO = new PolicyListDTO();
-            policyListDTO.setIdx(policy.getIdx());
-            policyListDTO.setCity(policy.getCity());
-            policyListDTO.setDistrict(policy.getDistrict());
-            policyListDTO.setType(policy.getType());
-            policyListDTO.setName(policy.getName());
-            policyListDTO.setOfferInst(policy.getOfferInst());
-            policyListDTO.setManageInst(policy.getManageInst());
-            policyListDTO.setStartDate(policy.getStartDate());
-            policyListDTO.setEndDate(policy.getEndDate());
-            policyListDTO.setApplyStartDate(policy.getApplyStartDate());
-            policyListDTO.setApplyEndDate(policy.getApplyEndDate());
-            return policyListDTO;
-        }).collect(Collectors.toList());
-    }
+//    public List<PolicyListDTO> getPolicyList() {
+//        List<PolicyList> policyList = policyListRepository.findAll();
+//
+//        return policyList.stream().map(policy -> {
+//            PolicyListDTO policyListDTO = new PolicyListDTO();
+//            policyListDTO.setIdx(policy.getIdx());
+//            policyListDTO.setCity(policy.getCity());
+//            policyListDTO.setDistrict(policy.getDistrict());
+//            policyListDTO.setType(policy.getType());
+//            policyListDTO.setName(policy.getName());
+//            policyListDTO.setOfferInst(policy.getOfferInst());
+//            policyListDTO.setManageInst(policy.getManageInst());
+//            policyListDTO.setStartDate(policy.getStartDate());
+//            policyListDTO.setEndDate(policy.getEndDate());
+//            policyListDTO.setApplyStartDate(policy.getApplyStartDate());
+//            policyListDTO.setApplyEndDate(policy.getApplyEndDate());
+//            return policyListDTO;
+//        }).collect(Collectors.toList());
+//    }
 
     public PolicyDetailDTO getPolicyDetail(Long idx) {
         PolicyDetail policyDetail = policyDetailRepository.findById(idx)

--- a/src/main/java/com/chapter1/blueprint/policy/service/PolicyDetailService.java
+++ b/src/main/java/com/chapter1/blueprint/policy/service/PolicyDetailService.java
@@ -60,6 +60,6 @@ public class PolicyDetailService {
     }
 
     public List<PolicyList> getPolicyListByFiltering(FilterDTO filterDTO) {
-         return policyListRepository.findByDistrictAndType(filterDTO.getDistrict(), filterDTO.getType());
+         return policyListRepository.findByDistrictAndType(filterDTO.getCity(), filterDTO.getDistrict(), filterDTO.getType());
     }
 }

--- a/src/main/java/com/chapter1/blueprint/security/config/SecurityConfig.java
+++ b/src/main/java/com/chapter1/blueprint/security/config/SecurityConfig.java
@@ -68,6 +68,7 @@ public class SecurityConfig {
                         .requestMatchers("/member/email/sendVerification", "/member/email/verifyEmailCode").permitAll()
                         .requestMatchers("/member/**").authenticated()
                         .requestMatchers("/policy/list/**", "/policy/detail/**", "policy/filter").permitAll()
+                        .requestMatchers("/subscription/city", "/subscription/district", "/subscription/local").permitAll()
                         .anyRequest().permitAll()
                 )
                 .exceptionHandling(exception -> exception

--- a/src/main/java/com/chapter1/blueprint/security/config/SecurityConfig.java
+++ b/src/main/java/com/chapter1/blueprint/security/config/SecurityConfig.java
@@ -67,7 +67,7 @@ public class SecurityConfig {
                         .requestMatchers("/member/find/memberId", "/member/find/password").permitAll()
                         .requestMatchers("/member/email/sendVerification", "/member/email/verifyEmailCode").permitAll()
                         .requestMatchers("/member/**").authenticated()
-                        .requestMatchers("/policy/list/**", "/policy/detail/**").permitAll()
+                        .requestMatchers("/policy/list/**", "/policy/detail/**", "policy/filter").permitAll()
                         .anyRequest().permitAll()
                 )
                 .exceptionHandling(exception -> exception

--- a/src/main/java/com/chapter1/blueprint/subscription/controller/SubscriptionController.java
+++ b/src/main/java/com/chapter1/blueprint/subscription/controller/SubscriptionController.java
@@ -2,13 +2,13 @@ package com.chapter1.blueprint.subscription.controller;
 
 import com.chapter1.blueprint.exception.dto.SuccessResponse;
 import com.chapter1.blueprint.subscription.domain.SubscriptionList;
+import com.chapter1.blueprint.subscription.domain.dto.ResidenceDTO;
+import com.chapter1.blueprint.subscription.service.ResidenceService;
 import com.chapter1.blueprint.subscription.service.SubscriptionService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -18,6 +18,7 @@ import java.util.List;
 @RequestMapping("/subscription")
 public class SubscriptionController {
     private final SubscriptionService subscriptionService;
+    private final ResidenceService residenceService;
 
     @GetMapping(value = "/update")
     public ResponseEntity<?> updateSubscription() {
@@ -30,4 +31,23 @@ public class SubscriptionController {
         List<SubscriptionList> subscriptionLists = subscriptionService.getAllSubscription();
         return ResponseEntity.ok(new SuccessResponse(subscriptionLists));
     }
+
+    @GetMapping("/city")
+    public ResponseEntity<SuccessResponse> getCityList() {
+        List<String> cityList = residenceService.getCityList();
+        return ResponseEntity.ok(new SuccessResponse(cityList));
+    }
+
+    @PostMapping("/district")
+    public ResponseEntity<SuccessResponse> getDistrict(@RequestBody ResidenceDTO residenceDTO) {
+        List<String> districtList = residenceService.getDistrict(residenceDTO);
+        return ResponseEntity.ok(new SuccessResponse(districtList));
+    }
+
+    @PostMapping("/local")
+    public ResponseEntity<SuccessResponse> getLocal(@RequestBody ResidenceDTO residenceDTO) {
+        List<String> localList = residenceService.getLocal(residenceDTO);
+        return ResponseEntity.ok(new SuccessResponse(localList));
+    }
+
 }

--- a/src/main/java/com/chapter1/blueprint/subscription/domain/RealEstatePrice.java
+++ b/src/main/java/com/chapter1/blueprint/subscription/domain/RealEstatePrice.java
@@ -1,9 +1,6 @@
 package com.chapter1.blueprint.subscription.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -12,6 +9,7 @@ import java.util.Date;
 
 @Entity
 @Getter @Setter
+@Table(name = "real_estate_price", catalog = "subscription")
 public class RealEstatePrice {
     @Id
     @GeneratedValue
@@ -19,30 +17,39 @@ public class RealEstatePrice {
     private Long idx;
 
     @Column(name = "region")
-    private String region;
-
-    @Column(name = "city")
     private String city;
 
-    @Column(name = "district")
+    @Column(name = "ssg_cd")
+    private String ssgCd;
+
+    @Column(name = "ssg_cd_nm")
     private String district;
 
-    @Column(name = "detail")
-    private String detail;
+    @Column(name = "umd_nm")
+    private String local;
 
-    @Column(name = "name")
-    private String name;
+    @Column(name = "jibun")
+    private String jibun;
 
-    @Column(name = "date")
-    private Date date;
+    @Column(name = "apt_nm")
+    private Date aptNm;
 
-    @Column(name = "price")
-    private Long price;
+    @Column(name = "deal_day")
+    private Long dealDay;
 
-    @Column(name = "diff_price")
-    private Long diffPrice;
+    @Column(name = "deal_month")
+    private Long dealMonth;
 
-    @Column(name = "diff_ratio")
-    private BigDecimal diffRatio;
+    @Column(name = "deal_year")
+    private BigDecimal dealYear;
+
+    @Column(name = "deal_date")
+    private BigDecimal dealDate;
+
+    @Column(name = "deal_amount")
+    private BigDecimal dealAmount;
+
+    @Column(name = "exclu_use_ar")
+    private BigDecimal excluUseAr;
 
 }

--- a/src/main/java/com/chapter1/blueprint/subscription/domain/dto/ResidenceDTO.java
+++ b/src/main/java/com/chapter1/blueprint/subscription/domain/dto/ResidenceDTO.java
@@ -1,0 +1,11 @@
+package com.chapter1.blueprint.subscription.domain.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ResidenceDTO {
+    private String city;
+    private String district;
+}

--- a/src/main/java/com/chapter1/blueprint/subscription/repository/RealEstatePriceRepository.java
+++ b/src/main/java/com/chapter1/blueprint/subscription/repository/RealEstatePriceRepository.java
@@ -1,11 +1,22 @@
 package com.chapter1.blueprint.subscription.repository;
 
-import jakarta.persistence.EntityManager;
-import lombok.RequiredArgsConstructor;
+import com.chapter1.blueprint.subscription.domain.RealEstatePrice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
-@RequiredArgsConstructor
-public class RealEstatePriceRepository {
-    private final EntityManager em;
+public interface RealEstatePriceRepository extends JpaRepository<RealEstatePrice, Long> {
+
+    @Query("SELECT DISTINCT city FROM RealEstatePrice")
+    List<String> getCityList();
+
+    @Query("SELECT DISTINCT district FROM RealEstatePrice WHERE city = :city")
+    List<String> getDistrict(@Param("city") String city);
+
+    @Query("SELECT DISTINCT local FROM RealEstatePrice WHERE city = :city AND district = :district")
+    List<String> getLocal(@Param("city") String city, @Param("district") String district);
 }

--- a/src/main/java/com/chapter1/blueprint/subscription/repository/RealEstatePriceRepository.java
+++ b/src/main/java/com/chapter1/blueprint/subscription/repository/RealEstatePriceRepository.java
@@ -14,9 +14,9 @@ public interface RealEstatePriceRepository extends JpaRepository<RealEstatePrice
     @Query("SELECT DISTINCT city FROM RealEstatePrice")
     List<String> getCityList();
 
-    @Query("SELECT DISTINCT district FROM RealEstatePrice WHERE city = :city")
+    @Query("SELECT DISTINCT district FROM RealEstatePrice WHERE city = :city ORDER BY district")
     List<String> getDistrict(@Param("city") String city);
 
-    @Query("SELECT DISTINCT local FROM RealEstatePrice WHERE city = :city AND district = :district")
+    @Query("SELECT DISTINCT local FROM RealEstatePrice WHERE city = :city AND district = :district ORDER BY local")
     List<String> getLocal(@Param("city") String city, @Param("district") String district);
 }

--- a/src/main/java/com/chapter1/blueprint/subscription/service/ResidenceService.java
+++ b/src/main/java/com/chapter1/blueprint/subscription/service/ResidenceService.java
@@ -1,0 +1,28 @@
+package com.chapter1.blueprint.subscription.service;
+
+import com.chapter1.blueprint.subscription.domain.dto.ResidenceDTO;
+import com.chapter1.blueprint.subscription.repository.RealEstatePriceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ResidenceService {
+    private final RealEstatePriceRepository realEstatePriceRepository;
+
+    public List<String> getCityList() {
+        return realEstatePriceRepository.getCityList();
+    }
+
+    public List<String> getDistrict(ResidenceDTO residenceDTO) {
+        return realEstatePriceRepository.getDistrict(residenceDTO.getCity());
+    }
+
+    public List<String> getLocal(ResidenceDTO residenceDTO) {
+        return realEstatePriceRepository.getLocal(residenceDTO.getCity(), residenceDTO.getDistrict());
+    }
+}


### PR DESCRIPTION
### #️⃣ 24.11.09 ~ 24.11.10

### 📝 작업 내용
- 조건(city, district, type)에 따라 정책 필터링 API 구현
- 마이페이지 거주지 상세정보(지역/지역구/읍면동) API 구현
- member 테이블 변경에 따라 코드 수정
- real_estate_table JPA 매칭명 변경
    - ssg_cd_nm -> district로 매칭
    - umd_nm -> local로 매칭