### PR TITLE
Fix: 맞춤형 서비스(정책, 청약)에서의 인증을 memberId에서 uid로 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,6 @@ repositories {
 }
 
 dependencies {
-    //
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -62,6 +61,9 @@ dependencies {
 
     implementation 'org.json:json:20230618'
 
+    // Spring Security 테스트 의존성
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
     // Swagger 의존성 추가
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 }

--- a/src/main/java/com/chapter1/blueprint/member/controller/MemberController.java
+++ b/src/main/java/com/chapter1/blueprint/member/controller/MemberController.java
@@ -6,6 +6,7 @@ import com.chapter1.blueprint.member.domain.dto.FindPasswordDTO;
 import com.chapter1.blueprint.member.domain.dto.PasswordDTO;
 import com.chapter1.blueprint.member.domain.dto.ProfileInfoDTO;
 import com.chapter1.blueprint.member.dto.MemberDTO;
+import com.chapter1.blueprint.member.repository.PolicyAlarmRepository;
 import com.chapter1.blueprint.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,7 +18,6 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
-
 import java.util.Map;
 
 @Slf4j
@@ -27,6 +27,7 @@ import java.util.Map;
 public class MemberController {
 
     private final MemberService memberService;
+
     private static final Logger logger = LoggerFactory.getLogger(MemberController.class);
 
     @PostMapping("/register")
@@ -98,7 +99,6 @@ public class MemberController {
         memberService.updatePassword(authenticatedMemberId, passwordDTO);
         return ResponseEntity.ok(new SuccessResponse("비밀번호 변경 성공"));
     }
-
 
     //@GetMapping(value = "/members/new")
     //public String createForm() {

--- a/src/main/java/com/chapter1/blueprint/member/controller/NotificationController.java
+++ b/src/main/java/com/chapter1/blueprint/member/controller/NotificationController.java
@@ -1,0 +1,154 @@
+package com.chapter1.blueprint.member.controller;
+
+import com.chapter1.blueprint.exception.dto.SuccessResponse;
+import com.chapter1.blueprint.member.domain.PolicyAlarm;
+import com.chapter1.blueprint.member.service.MemberService;
+import com.chapter1.blueprint.member.service.NotificationService;
+import com.chapter1.blueprint.policy.domain.PolicyDetailFilter;
+import com.chapter1.blueprint.policy.domain.PolicyList;
+import com.chapter1.blueprint.policy.repository.PolicyListRepository;
+import com.chapter1.blueprint.policy.service.PolicyRecommendationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/member/notification")
+public class NotificationController {
+
+    private final NotificationService notificationService;
+    private final MemberService memberService;
+    private final PolicyListRepository policyListRepository;
+    private final PolicyRecommendationService policyRecommendationService;
+
+    private static final Logger logger = LoggerFactory.getLogger(NotificationController.class);
+
+    @PutMapping("/status")
+    public ResponseEntity<String> updateNotificationStatus(@RequestBody Map<String, Object> request) {
+        try {
+            Long uid = memberService.getAuthenticatedUid();
+            log.info("Step 1 - Retrieved UID: {}", uid); // UID 값 확인
+
+            log.info("Step 2 - Request body: {}", request); // 요청 데이터 확인
+            boolean notificationEnabled = (Boolean) request.get("notificationEnabled");
+
+            log.info("Step 3 - About to call notificationService with uid: {} and enabled: {}",
+                    uid, notificationEnabled); // 서비스 호출 직전 확인
+
+            notificationService.updateNotificationStatus(uid, notificationEnabled);
+
+            log.info("Step 4 - Successfully updated notification status"); // 성공 확인
+
+            return ResponseEntity.ok("Notification status updated successfully.");
+        } catch (Exception e) {
+            log.error("Failed to update notification status", e);
+            throw e;
+        }
+    }
+
+    @PutMapping("/{policyIdx}")
+    public ResponseEntity<String> updateNotificationSettings(
+            @PathVariable Long policyIdx,
+            @RequestBody Map<String, Object> request) {
+        Long uid = memberService.getAuthenticatedUid();
+        boolean notificationEnabled = (Boolean) request.get("notificationEnabled");
+        Date applyEndDate = (Date) request.get("applyEndDate");
+
+        notificationService.saveOrUpdateNotification(uid, policyIdx, notificationEnabled, applyEndDate);
+
+        return ResponseEntity.ok("Notification settings updated successfully.");
+    }
+
+    @DeleteMapping("/{policyIdx}")
+    public ResponseEntity<String> deleteNotificationSettings(@PathVariable Long policyIdx) {
+        Long uid = memberService.getAuthenticatedUid();
+        notificationService.deleteNotification(uid, policyIdx);
+        return ResponseEntity.ok("Notification settings deleted successfully.");
+    }
+
+    @GetMapping("/list/member")
+    public ResponseEntity<?> getMemberDefinedNotifications() {
+        Long uid = memberService.getAuthenticatedUid();
+        List<PolicyAlarm> memberNotifications = notificationService.getMemberNotifications(uid);
+        return ResponseEntity.ok(new SuccessResponse(memberNotifications));
+    }
+
+    @GetMapping("/list/recommended")
+    public ResponseEntity<?> getRecommendedNotifications() {
+        Long uid = memberService.getAuthenticatedUid();
+        List<PolicyAlarm> recommendedNotifications = notificationService.getRecommendedNotifications(uid);
+        return ResponseEntity.ok(new SuccessResponse(recommendedNotifications));
+    }
+
+    @GetMapping("/dashboard")
+    public ResponseEntity<Map<String, Object>> getNotificationDashboard() {
+        Long uid = memberService.getAuthenticatedUid();
+
+        // 사용자 설정 알림
+        List<PolicyAlarm> memberNotifications = notificationService.getMemberNotifications(uid);
+
+        // 추천된 정책 알림
+        List<PolicyAlarm> recommendedNotifications = notificationService.getRecommendedNotifications(uid);
+
+        // 추천된 정책 (실시간 추천)
+        List<PolicyDetailFilter> recommendedPolicies = policyRecommendationService.getRecommendedPolicies(uid);
+
+        Map<String, Object> dashboard = new HashMap<>();
+        dashboard.put("memberNotifications", memberNotifications.stream()
+                .map(alarm -> {
+                    PolicyList policy = policyListRepository.findById(alarm.getPolicyIdx())
+                            .orElse(null);
+                    if (policy != null && policy.getName() != null && policy.getApplyEndDate() != null) {
+                        return Map.of(
+                                "policyName", policy.getName(),
+                                "applyEndDate", policy.getApplyEndDate()
+                        );
+                    }
+                    return null;
+                })
+                .filter(map -> map != null)
+                .toList());
+
+        dashboard.put("recommendedNotifications", recommendedNotifications.stream()
+                .map(alarm -> {
+                    PolicyList policy = policyListRepository.findById(alarm.getPolicyIdx())
+                            .orElse(null);
+                    if (policy != null && policy.getName() != null && policy.getApplyEndDate() != null) {
+                        return Map.of(
+                                "policyName", policy.getName(),
+                                "applyEndDate", policy.getApplyEndDate()
+                        );
+                    }
+                    return null;
+                })
+                .filter(map -> map != null)
+                .toList());
+
+        dashboard.put("recommendedPolicies", recommendedPolicies.stream()
+                .map(policy -> {
+                    if (policy.getTarget() != null && policy.getApplyEndDate() != null) {
+                        return Map.of(
+                                "policyName", policy.getTarget(),
+                                "applyEndDate", policy.getApplyEndDate()
+                        );
+                    }
+                    return null;
+                })
+                .filter(map -> map != null)
+                .toList());
+
+        return ResponseEntity.ok(dashboard);
+    }
+
+}

--- a/src/main/java/com/chapter1/blueprint/member/domain/Member.java
+++ b/src/main/java/com/chapter1/blueprint/member/domain/Member.java
@@ -94,4 +94,7 @@ public class Member {
 
     @Column(name = "expiration", nullable = true)
     private Timestamp expiration;
+
+    @Column(name = "notification_status")
+    private Boolean notificationStatus = false;
 }

--- a/src/main/java/com/chapter1/blueprint/member/domain/PolicyAlarm.java
+++ b/src/main/java/com/chapter1/blueprint/member/domain/PolicyAlarm.java
@@ -1,17 +1,18 @@
 package com.chapter1.blueprint.member.domain;
 
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 import java.util.Date;
 
 @Entity
+@Builder
 @Getter @Setter
+@NoArgsConstructor @AllArgsConstructor
 @Table(name = "policy_alarm", catalog = "member")
 public class PolicyAlarm {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "idx")
     private Long idx;
 
@@ -26,4 +27,13 @@ public class PolicyAlarm {
 
     @Column(name = "send_date")
     private Date sendDate;
+
+    @Column(name = "policy_idx")
+    private Long policyIdx;
+
+    @Column(name = "notification_enabled")
+    private Boolean notificationEnabled = false;
+
+    @Column(name = "apply_end_date")
+    private Date applyEndDate;
 }

--- a/src/main/java/com/chapter1/blueprint/member/repository/MemberRepository.java
+++ b/src/main/java/com/chapter1/blueprint/member/repository/MemberRepository.java
@@ -21,5 +21,4 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     @Query("SELECT m.password FROM Member m WHERE m.memberId = :memberId")
     String findPasswordByMemberId(@Param("memberId") String memberId);
-
 }

--- a/src/main/java/com/chapter1/blueprint/member/repository/PolicyAlarmRepository.java
+++ b/src/main/java/com/chapter1/blueprint/member/repository/PolicyAlarmRepository.java
@@ -3,8 +3,35 @@ package com.chapter1.blueprint.member.repository;
 import com.chapter1.blueprint.member.domain.FinanceRecommend;
 import com.chapter1.blueprint.member.domain.PolicyAlarm;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.Date;
+import java.util.List;
 
 @Repository
 public interface PolicyAlarmRepository extends JpaRepository<PolicyAlarm, Long> {
+
+    PolicyAlarm findByUidAndPolicyIdx(Long uid, Long policyIdx);
+
+    List<PolicyAlarm> findByNotificationEnabled(Boolean notificationEnabled);
+
+    List<PolicyAlarm> findByUid(Long uid);
+
+    List<PolicyAlarm> findByUidAndAlarmType(Long uid, String alarmType);
+
+    @Query("SELECT p FROM PolicyAlarm p WHERE p.notificationEnabled = true AND p.applyEndDate <= :applyEndDate")
+    List<PolicyAlarm> findEnabledNotificationsBeforeDeadline(@Param("applyEndDate") Date applyEndDate);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM PolicyAlarm pa WHERE pa.policyIdx = :policyIdx")
+    void deleteByPolicyIdx(@Param("policyIdx") Long policyIdx);
+
+
+
 }
+

--- a/src/main/java/com/chapter1/blueprint/member/service/EmailService.java
+++ b/src/main/java/com/chapter1/blueprint/member/service/EmailService.java
@@ -2,11 +2,16 @@ package com.chapter1.blueprint.member.service;
 
 import com.chapter1.blueprint.exception.codes.ErrorCode;
 import com.chapter1.blueprint.exception.codes.ErrorCodeException;
+import com.chapter1.blueprint.member.controller.MemberController;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.mail.MailException;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
+
+import java.sql.Date;
 import java.util.concurrent.ConcurrentHashMap;
 
 import java.time.LocalDateTime;
@@ -17,6 +22,7 @@ import java.util.Map;
 public class EmailService {
 
     private final JavaMailSender mailSender;
+    private static final Logger logger = LoggerFactory.getLogger(EmailService.class);
     private final Map<String, VerificationData> verificationCodes = new ConcurrentHashMap<>();
 
     private static final long CODE_EXPIRATION_MINUTES = 5;
@@ -106,4 +112,32 @@ public class EmailService {
         );
         mailSender.send(message);
     }
+
+    public void sendNotificationEmail(String to, String policyName, Date endDate, Long idx) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(to);
+        message.setSubject("[BluePrint] Policy Deadline Reminder");
+
+        String policyDetailLink = "http://localhost:5173/policy/detail/" + idx;  // 정책 상세 페이지 링크
+
+        message.setText(
+                "안녕하세요,\n\n" +
+                        "BluePrint 서비스를 이용해주셔서 감사합니다!\n\n" +
+                        "알려드릴 사항: 정책 '" + policyName + "'의 신청 마감일이 3일 남았습니다.\n\n" +
+                        "종료일: " + endDate + "\n\n" +
+                        "자세한 정책 내용은 아래 링크를 통해 확인해 주세요:\n" +
+                        policyDetailLink + "\n\n" +
+                        "마감일을 놓치지 않도록 미리 준비해 주세요.\n\n" +
+                        "감사합니다.\n" +
+                        "BluePrint 팀 드림"
+        );
+
+        try {
+            mailSender.send(message);
+            logger.info("Email sent to: {}", to);
+        } catch (Exception e) {
+            logger.error("Failed to send email to: {}", to, e);
+        }
+    }
+
 }

--- a/src/main/java/com/chapter1/blueprint/member/service/NotificationService.java
+++ b/src/main/java/com/chapter1/blueprint/member/service/NotificationService.java
@@ -1,0 +1,95 @@
+package com.chapter1.blueprint.member.service;
+
+import com.chapter1.blueprint.member.domain.PolicyAlarm;
+import com.chapter1.blueprint.member.repository.PolicyAlarmRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final PolicyAlarmRepository policyAlarmRepository;
+
+    private static final Logger logger = LoggerFactory.getLogger(NotificationService.class);
+
+    public void updateNotificationStatus(Long uid, boolean enabled) {
+        log.info("Step 5 - Starting updateNotificationStatus for UID: {}", uid);
+
+        try {
+            List<PolicyAlarm> alarms = policyAlarmRepository.findByUid(uid);
+            log.info("Step 6 - Found {} PolicyAlarms for UID: {}", alarms.size(), uid);
+
+            if (alarms.isEmpty()) {
+                log.info("Step 7a - No existing PolicyAlarm. Creating new one for UID: {}", uid);
+                PolicyAlarm newAlarm = PolicyAlarm.builder()
+                        .uid(uid)
+                        .notificationEnabled(enabled)
+                        .policyIdx(0L)  // 또는 적절한 기본값
+                        .alarmType("MEMBER_DEFINED")  // 알람 타입 설정
+                        .build();
+                policyAlarmRepository.save(newAlarm);
+                log.info("Step 8a - Successfully created new PolicyAlarm");
+            } else {
+                log.info("Step 7b - Updating {} existing PolicyAlarms", alarms.size());
+                for (PolicyAlarm alarm : alarms) {
+                    alarm.setNotificationEnabled(enabled);
+                }
+                policyAlarmRepository.saveAll(alarms);
+                log.info("Step 8b - Successfully updated existing PolicyAlarms");
+            }
+        } catch (Exception e) {
+            log.error("Error in updateNotificationStatus", e);
+            throw e;
+        }
+    }
+
+    public void saveOrUpdateNotification(Long uid, Long policyIdx, boolean notificationEnabled, Date applyEndDate) {
+        PolicyAlarm alarm = policyAlarmRepository.findByUidAndPolicyIdx(uid, policyIdx);
+
+        if (alarm == null) {
+            alarm = new PolicyAlarm();
+            alarm.setUid(uid);
+            alarm.setPolicyIdx(policyIdx);
+            alarm.setNotificationEnabled(notificationEnabled);
+            alarm.setApplyEndDate(applyEndDate);
+        } else {
+            alarm.setNotificationEnabled(notificationEnabled);
+            alarm.setApplyEndDate(applyEndDate);
+        }
+
+        policyAlarmRepository.save(alarm);
+    }
+
+    public void deleteNotification(Long uid, Long policyIdx) {
+        PolicyAlarm alarm = policyAlarmRepository.findByUidAndPolicyIdx(uid, policyIdx);
+
+        if (alarm == null) {
+            throw new IllegalArgumentException("Notification not found for uid: " + uid + ", policyIdx: " + policyIdx);
+        }
+
+        policyAlarmRepository.delete(alarm);
+    }
+
+    public List<PolicyAlarm> getMemberNotifications(Long uid) {
+        return policyAlarmRepository.findByUidAndAlarmType(uid, "MEMBER_DEFINED")
+                .stream()
+                .filter(alarm -> alarm.getNotificationEnabled() != null && alarm.getNotificationEnabled())
+                .collect(Collectors.toList());
+    }
+
+    public List<PolicyAlarm> getRecommendedNotifications(Long uid) {
+        return policyAlarmRepository.findByUidAndAlarmType(uid, "RECOMMENDED")
+                .stream()
+                .filter(alarm -> alarm.getApplyEndDate() != null)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/chapter1/blueprint/policy/controller/PolicyController.java
+++ b/src/main/java/com/chapter1/blueprint/policy/controller/PolicyController.java
@@ -26,6 +26,7 @@ public class PolicyController {
 
     private final PolicyService policyService;
     private final PolicyDetailService policyDetailService;
+    private final MemberService memberService;
 
     @GetMapping(value = "/update/TK")
     public ResponseEntity<?> updatePolicyTK() {
@@ -65,10 +66,9 @@ public class PolicyController {
 
     @GetMapping("/recommendation")
     public ResponseEntity<SuccessResponse> recommendPolicy() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        String authenticatedMemberId = authentication.getName();
+        Long uid = memberService.getAuthenticatedUid();
 
-        List<PolicyList> recommendedPolicy = policyDetailService.recommendPolicy(authenticatedMemberId);
+        List<PolicyList> recommendedPolicy = policyDetailService.recommendPolicy(uid);
         return ResponseEntity.ok(new SuccessResponse(recommendedPolicy));
     }
 }

--- a/src/main/java/com/chapter1/blueprint/policy/controller/PolicyController.java
+++ b/src/main/java/com/chapter1/blueprint/policy/controller/PolicyController.java
@@ -1,6 +1,7 @@
 package com.chapter1.blueprint.policy.controller;
 
 import com.chapter1.blueprint.exception.dto.SuccessResponse;
+import com.chapter1.blueprint.member.service.MemberService;
 import com.chapter1.blueprint.policy.domain.PolicyList;
 import com.chapter1.blueprint.policy.domain.dto.FilterDTO;
 import com.chapter1.blueprint.policy.domain.dto.PolicyDetailDTO;
@@ -10,6 +11,7 @@ import com.chapter1.blueprint.policy.service.PolicyService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
@@ -47,6 +49,18 @@ public class PolicyController {
     public ResponseEntity<SuccessResponse> getPolicyListByFiltering(@RequestBody FilterDTO filterDTO) {
         List<PolicyList> policyListByFiltering = policyDetailService.getPolicyListByFiltering(filterDTO);
         return ResponseEntity.ok(new SuccessResponse(policyListByFiltering));
+    }
+
+    @GetMapping("/deadline")
+    public ResponseEntity<SuccessResponse> checkPolicyDeadline() {
+        List<PolicyListDTO> policies = policyService.findPoliciesWithApproachingDeadline();
+        return ResponseEntity.ok(new SuccessResponse(policies));
+    }
+
+    @PostMapping("/manual-check-deadline")
+    public ResponseEntity<String> manualCheckPolicyDeadline() {
+        checkPolicyDeadline();
+        return ResponseEntity.ok("Policy deadline check triggered manually.");
     }
 
     @GetMapping("/recommendation")

--- a/src/main/java/com/chapter1/blueprint/policy/controller/PolicyDeadlineScheduler.java
+++ b/src/main/java/com/chapter1/blueprint/policy/controller/PolicyDeadlineScheduler.java
@@ -1,0 +1,108 @@
+package com.chapter1.blueprint.policy.controller;
+
+import com.chapter1.blueprint.member.domain.Member;
+import com.chapter1.blueprint.member.domain.PolicyAlarm;
+import com.chapter1.blueprint.member.repository.MemberRepository;
+import com.chapter1.blueprint.member.repository.PolicyAlarmRepository;
+import com.chapter1.blueprint.member.service.EmailService;
+import com.chapter1.blueprint.policy.domain.PolicyDetailFilter;
+import com.chapter1.blueprint.policy.domain.PolicyList;
+import com.chapter1.blueprint.policy.repository.PolicyListRepository;
+import com.chapter1.blueprint.policy.service.PolicyRecommendationService;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.sql.Date;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class PolicyDeadlineScheduler {
+
+    private final PolicyAlarmRepository policyAlarmRepository;
+    private final PolicyListRepository policyListRepository;
+    private final EmailService emailService;
+    private final MemberRepository memberRepository;
+    private final PolicyRecommendationService policyRecommendationService; // 추천 서비스 추가
+    private static final Logger logger = LoggerFactory.getLogger(PolicyDeadlineScheduler.class);
+
+    @Scheduled(cron = "0 0 0 * * ?")
+    public void checkPolicyDeadline() {
+        logger.info("Starting policy deadline check...");
+
+        // 사용자가 설정한 정책 알림
+        checkMemberSetPolicyAlarms();
+
+        // 추천 정책 알림
+        checkRecommendedPolicyAlarms();
+    }
+
+    private void checkMemberSetPolicyAlarms() {
+        List<PolicyAlarm> notificationSettings = policyAlarmRepository.findByNotificationEnabled(true);
+
+        for (PolicyAlarm setting : notificationSettings) {
+            PolicyList policy = policyListRepository.findById(setting.getPolicyIdx()).orElse(null);
+
+            if (policy != null) {
+                Date applyEndDate = (Date) policy.getApplyEndDate();
+
+                if (isThreeDaysBefore(applyEndDate)) {
+                    sendNotificationToMemberForPolicy(policy, setting.getUid());
+                }
+            }
+        }
+    }
+
+    private void checkRecommendedPolicyAlarms() {
+        List<Member> members = memberRepository.findAll();
+
+        for (Member member : members) {
+            List<PolicyDetailFilter> recommendedPolicies = policyRecommendationService.getRecommendedPolicies(member.getUid());
+
+            for (PolicyDetailFilter policy : recommendedPolicies) {
+                if (isThreeDaysBefore(policy.getApplyEndDate())) {
+                    sendRecommendationEmail(member, policy);
+                }
+            }
+        }
+    }
+
+    private boolean isThreeDaysBefore(Date applyEndDate) {
+        LocalDate endDate = applyEndDate.toLocalDate();
+        LocalDate currentDate = LocalDate.now();
+
+        long daysBetween = ChronoUnit.DAYS.between(currentDate, endDate);
+
+        return daysBetween == 3;
+    }
+
+    private void sendNotificationToMemberForPolicy(PolicyList policyList, Long uid) {
+        String policyName = policyList.getName();
+        Date endDate = (Date) policyList.getApplyEndDate();
+        Long idx = policyList.getIdx();
+
+        Member member = memberRepository.findById(uid)
+                .orElseThrow(() -> new IllegalArgumentException("Member not found with UID: " + uid));
+
+        emailService.sendNotificationEmail(member.getEmail(), policyName, endDate, idx);
+        logger.info("Email sent to: {} for policy: {}", member.getEmail(), policyName);
+    }
+
+    private void sendRecommendationEmail(Member member, PolicyDetailFilter policy) {
+        PolicyList policyList = policyListRepository.findById(policy.getIdx())
+                .orElseThrow(() -> new IllegalArgumentException("Policy not found with ID: " + policy.getIdx()));
+
+        String policyName = policyList.getName();
+        Date endDate = policy.getApplyEndDate();
+        Long idx = policy.getIdx();
+
+        emailService.sendNotificationEmail(member.getEmail(), policyName, endDate, idx);
+        logger.info("Recommendation email sent to: {} for policy: {}", member.getEmail(), policyName);
+    }
+
+}

--- a/src/main/java/com/chapter1/blueprint/policy/domain/PolicyDetailFilter.java
+++ b/src/main/java/com/chapter1/blueprint/policy/domain/PolicyDetailFilter.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.sql.Date;
+
 @Entity
 @Getter @Setter
 @Table(name = "policy_detail_filter", catalog = "policy")
@@ -33,4 +35,7 @@ public class PolicyDetailFilter {
 
     @Column(name = "job")
     private String job;
+
+    @Column(name = "apply_end_date")
+    private Date applyEndDate;
 }

--- a/src/main/java/com/chapter1/blueprint/policy/repository/PolicyDetailFilterRepository.java
+++ b/src/main/java/com/chapter1/blueprint/policy/repository/PolicyDetailFilterRepository.java
@@ -1,10 +1,17 @@
 package com.chapter1.blueprint.policy.repository;
 
-import com.chapter1.blueprint.policy.domain.PolicyDetail;
 import com.chapter1.blueprint.policy.domain.PolicyDetailFilter;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface PolicyDetailFilterRepository extends JpaRepository<PolicyDetailFilter, Long> {
+    @Query("SELECT p FROM PolicyDetailFilter p WHERE p.region = :region AND (p.minAge IS NULL OR :age >= p.minAge) AND (p.maxAge IS NULL OR :age <= p.maxAge) AND (p.job IS NULL OR p.job = :job)")
+    List<PolicyDetailFilter> findRecommendedPoliciesByUid(@Param("region") String region,
+                                                          @Param("age") Integer age,
+                                                          @Param("job") String job);
 }

--- a/src/main/java/com/chapter1/blueprint/policy/repository/PolicyListRepository.java
+++ b/src/main/java/com/chapter1/blueprint/policy/repository/PolicyListRepository.java
@@ -1,5 +1,6 @@
 package com.chapter1.blueprint.policy.repository;
 
+import com.chapter1.blueprint.policy.domain.dto.PolicyListDTO;
 import org.springframework.data.jpa.repository.JpaRepository;
 import com.chapter1.blueprint.policy.domain.PolicyList;
 import org.springframework.data.jpa.repository.Query;
@@ -27,6 +28,9 @@ public interface PolicyListRepository extends JpaRepository<PolicyList,Long> {
             @Param("job") String job,
             @Param("name") String name);
 
+    @Query("SELECT p FROM PolicyList p WHERE DATEDIFF(p.applyEndDate, CURRENT_DATE) = 3")
+    List<PolicyListDTO> findPoliciesWithApproachingDeadline();
+    
     @Query("SELECT p FROM PolicyList p " +
             "JOIN PolicyDetailFilter f ON p.idx = f.idx " +
             "WHERE (:city IS NULL OR p.city = :city) " +

--- a/src/main/java/com/chapter1/blueprint/policy/service/PolicyDetailService.java
+++ b/src/main/java/com/chapter1/blueprint/policy/service/PolicyDetailService.java
@@ -55,9 +55,9 @@ public class PolicyDetailService {
          return policyListRepository.findByCityDistrictTypeAgeJob(filterDTO.getCity(), filterDTO.getDistrict(), filterDTO.getType(), filterDTO.getAge(), filterDTO.getJob(), filterDTO.getName());
     }
 
-    public List<PolicyList> recommendPolicy(String memberId) {
-        Member member = memberRepository.findByMemberId(memberId)
-                .orElseThrow(() -> new RuntimeException("Member not found with ID (recommendPolicy): " + memberId));;
+    public List<PolicyList> recommendPolicy(Long uid) {
+        Member member = memberRepository.findById(uid)
+                .orElseThrow(() -> new RuntimeException("Member not found with uid (recommendPolicy): " + uid));
 
         int age = memberService.calculateAge(member.getBirthYear());
         return policyListRepository.findByCityDistrictAgeJob(member.getRegion(), member.getDistrict(), age, member.getOccupation());

--- a/src/main/java/com/chapter1/blueprint/policy/service/PolicyRecommendationService.java
+++ b/src/main/java/com/chapter1/blueprint/policy/service/PolicyRecommendationService.java
@@ -1,0 +1,28 @@
+package com.chapter1.blueprint.policy.service;
+
+import com.chapter1.blueprint.member.domain.Member;
+import com.chapter1.blueprint.member.repository.MemberRepository;
+import com.chapter1.blueprint.member.service.MemberService;
+import com.chapter1.blueprint.policy.domain.PolicyDetailFilter;
+import com.chapter1.blueprint.policy.repository.PolicyDetailFilterRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PolicyRecommendationService {
+
+    private final PolicyDetailFilterRepository policyDetailFilterRepository;
+    private final MemberService memberService;
+
+    public List<PolicyDetailFilter> getRecommendedPolicies(Long uid) {
+        Member member = memberService.getMemberByUid(uid);
+
+        Integer age = memberService.calculateAge(member.getBirthYear());
+
+        return policyDetailFilterRepository.findRecommendedPoliciesByUid(member.getRegion(), age, member.getOccupation());
+    }
+}

--- a/src/main/java/com/chapter1/blueprint/policy/service/PolicyService.java
+++ b/src/main/java/com/chapter1/blueprint/policy/service/PolicyService.java
@@ -1,7 +1,9 @@
 package com.chapter1.blueprint.policy.service;
 
+import com.chapter1.blueprint.member.repository.PolicyAlarmRepository;
 import com.chapter1.blueprint.policy.domain.PolicyDetail;
 import com.chapter1.blueprint.policy.domain.PolicyList;
+import com.chapter1.blueprint.policy.domain.dto.PolicyListDTO;
 import com.chapter1.blueprint.policy.repository.PolicyDetailRepository;
 import com.chapter1.blueprint.policy.repository.PolicyListRepository;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -18,6 +20,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.List;
 
 @Service
 @Transactional
@@ -26,6 +29,7 @@ import java.util.Date;
 public class PolicyService {
     private final PolicyListRepository policyListRepository;
     private final PolicyDetailRepository policyDetailRepositpry;
+    private final PolicyAlarmRepository policyAlarmRepository;
 
     @Value("${tk.policy.api.url}")
     private String policyApiUrlTK;
@@ -105,4 +109,16 @@ public class PolicyService {
             return null;
         }
     }
+
+    public List<PolicyListDTO> findPoliciesWithApproachingDeadline() {
+        return policyListRepository.findPoliciesWithApproachingDeadline();
+    }
+
+    @Transactional
+    public void deletePolicy(Long policyIdx) {
+        policyListRepository.deleteById(policyIdx);
+
+        policyAlarmRepository.deleteByPolicyIdx(policyIdx);
+    }
+
 }

--- a/src/main/java/com/chapter1/blueprint/security/config/SecurityConfig.java
+++ b/src/main/java/com/chapter1/blueprint/security/config/SecurityConfig.java
@@ -62,10 +62,16 @@ public class SecurityConfig {
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.OPTIONS).permitAll()
-                        .requestMatchers("/member/login", "/member/register").permitAll()
-                        .requestMatchers("/member/checkMemberId/**", "/member/checkEmail/**").permitAll()
-                        .requestMatchers("/member/find/memberId", "/member/find/password").permitAll()
-                        .requestMatchers("/member/email/sendVerification", "/member/email/verifyEmailCode").permitAll()
+                        .requestMatchers(
+                                "/member/login",
+                                "/member/register",
+                                "/member/checkMemberId/**",
+                                "/member/checkEmail/**",
+                                "/member/find/memberId",
+                                "/member/find/password",
+                                "/member/email/sendVerification",
+                                "/member/email/verifyEmailCode"
+                        ).permitAll()
                         .requestMatchers("/member/**").authenticated()
                         .requestMatchers("/finance/filter/**").authenticated()
                         .requestMatchers("/policy/recommendation").authenticated()
@@ -82,8 +88,8 @@ public class SecurityConfig {
                         .accessDeniedHandler(accessDeniedHandler)
                 )
                 .addFilterBefore(authenticationErrorFilter, UsernamePasswordAuthenticationFilter.class)
-                .addFilterBefore(jwtUsernamePasswordAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
-                .addFilterBefore(jwtAuthenticationFilter, JwtUsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterAt(jwtUsernamePasswordAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/chapter1/blueprint/security/controller/AuthController.java
+++ b/src/main/java/com/chapter1/blueprint/security/controller/AuthController.java
@@ -27,7 +27,7 @@ public class AuthController {
 
         if (jwtProcessor.validateRefreshToken(refreshToken)) {
             Member member = memberRepository.findByMemberId(memberId)
-                    .orElseThrow(() -> new RuntimeException("Invalid User"));
+                    .orElseThrow(() -> new RuntimeException("Invalid Member"));
 
             String newAccessToken = jwtProcessor.generateAccessToken(
                     member.getMemberId(),

--- a/src/main/java/com/chapter1/blueprint/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/chapter1/blueprint/security/filter/JwtAuthenticationFilter.java
@@ -7,6 +7,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -14,6 +15,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
@@ -24,22 +26,57 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
+        // 1. Authorization 헤더 추출
         String header = request.getHeader("Authorization");
+        log.info("Authorization Header: {}", header);
 
         if (header != null && header.startsWith("Bearer ")) {
+            // 2. JWT 토큰 추출
             String token = header.substring(7);
+            log.info("Extracted Token: {}", token);
 
-            if (jwtProcessor.validateToken(token)) {
-                var authentication = jwtProcessor.getAuthentication(token);
-                SecurityContextHolder.getContext().setAuthentication(authentication);
-            } else {
-                jsonResponseUtil.sendErrorResponse(response, HttpStatus.UNAUTHORIZED,
-                        "Invalid or expired token in authorization header.",
-                        "The provided token is invalid or expired.");
+            try {
+                // 3. 토큰 검증
+                if (jwtProcessor.validateToken(token)) {
+                    log.info("Token is valid: {}", token);
+
+                    // 4. 인증 객체 생성 및 SecurityContextHolder 설정
+                    var authentication = jwtProcessor.getAuthentication(token);
+                    if (authentication != null) {
+                        SecurityContextHolder.getContext().setAuthentication(authentication);
+                        log.info("Authentication set in SecurityContextHolder: {}", authentication);
+                    } else {
+                        log.warn("Failed to create authentication from token: {}", token);
+                    }
+                } else {
+                    log.warn("Invalid or expired token: {}", token);
+                    jsonResponseUtil.sendErrorResponse(
+                            response,
+                            HttpStatus.UNAUTHORIZED,
+                            "Invalid or expired token in authorization header.",
+                            "The provided token is invalid or expired."
+                    );
+                    return;
+                }
+            } catch (Exception e) {
+                log.error("Error processing JWT token: {}", token, e);
+                jsonResponseUtil.sendErrorResponse(
+                        response,
+                        HttpStatus.UNAUTHORIZED,
+                        "Error processing token.",
+                        e.getMessage()
+                );
                 return;
+            }
+        } else {
+            if (header == null) {
+                log.warn("Authorization header is missing.");
+            } else {
+                log.warn("Authorization header does not start with 'Bearer '. Header: {}", header);
             }
         }
 
+        // 5. 필터 체인으로 요청 전달
         filterChain.doFilter(request, response);
     }
 }

--- a/src/main/java/com/chapter1/blueprint/subscription/controller/SubscriptionController.java
+++ b/src/main/java/com/chapter1/blueprint/subscription/controller/SubscriptionController.java
@@ -1,6 +1,7 @@
 package com.chapter1.blueprint.subscription.controller;
 
 import com.chapter1.blueprint.exception.dto.SuccessResponse;
+import com.chapter1.blueprint.member.service.MemberService;
 import com.chapter1.blueprint.policy.domain.PolicyList;
 import com.chapter1.blueprint.subscription.domain.SubscriptionList;
 import com.chapter1.blueprint.subscription.domain.DTO.ResidenceDTO;
@@ -24,6 +25,7 @@ import java.util.List;
 public class SubscriptionController {
     private final SubscriptionService subscriptionService;
     private final ResidenceService residenceService;
+    private final MemberService memberService;
 
     @GetMapping(value = "/update")
     public ResponseEntity<?> updateSubscription() {
@@ -65,10 +67,9 @@ public class SubscriptionController {
 
     @GetMapping("/recommendation")
     public ResponseEntity<SuccessResponse> recommendSubscription() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        String authenticatedMemberId = authentication.getName();
+        Long uid = memberService.getAuthenticatedUid();
 
-        List<SubscriptionList> recommendedSubscription = subscriptionService.recommendSubscription(authenticatedMemberId);
+        List<SubscriptionList> recommendedSubscription = subscriptionService.recommendSubscription(uid);
         return ResponseEntity.ok(new SuccessResponse(recommendedSubscription));
     }
 

--- a/src/main/java/com/chapter1/blueprint/subscription/service/SubscriptionService.java
+++ b/src/main/java/com/chapter1/blueprint/subscription/service/SubscriptionService.java
@@ -253,9 +253,9 @@ public class SubscriptionService {
         return subscriptionListRepository.findAll();
     }
 
-    public List<SubscriptionList> recommendSubscription(String memberId) {
-        Member member = memberRepository.findByMemberId(memberId)
-                .orElseThrow(() -> new RuntimeException("Member not found with ID (recommendSubscription): " + memberId));
+    public List<SubscriptionList> recommendSubscription(Long uid) {
+        Member member = memberRepository.findById(uid)
+                .orElseThrow(() -> new RuntimeException("Member not found with uid (recommendSubscription): " + uid));
 
         return subscriptionListRepository.findByRegionAndCityAndDistrictContaining(member.getRegion(), member.getDistrict(), member.getLocal());
     }

--- a/src/test/java/com/chapter1/blueprint/member/controller/NotificationControllerTest.java
+++ b/src/test/java/com/chapter1/blueprint/member/controller/NotificationControllerTest.java
@@ -1,0 +1,186 @@
+package com.chapter1.blueprint.member.controller;
+
+import com.chapter1.blueprint.exception.dto.SuccessResponse;
+import com.chapter1.blueprint.member.domain.PolicyAlarm;
+import com.chapter1.blueprint.member.service.MemberService;
+import com.chapter1.blueprint.member.service.NotificationService;
+import com.chapter1.blueprint.policy.domain.PolicyDetailFilter;
+import com.chapter1.blueprint.policy.domain.PolicyList;
+import com.chapter1.blueprint.policy.repository.PolicyListRepository;
+import com.chapter1.blueprint.policy.service.PolicyRecommendationService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+class NotificationControllerTest {
+
+    @Mock
+    private NotificationService notificationService;
+
+    @Mock
+    private MemberService memberService;
+
+    @Mock
+    private PolicyRecommendationService policyRecommendationService;
+
+    @Mock
+    private PolicyListRepository policyListRepository;
+
+    @InjectMocks
+    private NotificationController notificationController;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testUpdateNotificationStatus_EnableNotifications() {
+        // 알림을 ON으로 설정하는 테스트
+        Long mockUid = 123L;
+        when(memberService.getAuthenticatedUid()).thenReturn(mockUid);
+
+        Map<String, Object> request = new HashMap<>();
+        request.put("notificationEnabled", true);
+
+        ResponseEntity<String> response = notificationController.updateNotificationStatus(request);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals("Notification status updated successfully.", response.getBody());
+        verify(notificationService, times(1)).updateNotificationStatus(mockUid, true);
+    }
+
+    @Test
+    void testUpdateNotificationStatus_DisableNotifications() {
+        // 알림을 OFF로 설정하는 테스트
+        Long mockUid = 123L;
+        when(memberService.getAuthenticatedUid()).thenReturn(mockUid);
+
+        Map<String, Object> request = new HashMap<>();
+        request.put("notificationEnabled", false);
+
+        ResponseEntity<String> response = notificationController.updateNotificationStatus(request);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals("Notification status updated successfully.", response.getBody());
+        verify(notificationService, times(1)).updateNotificationStatus(mockUid, false);
+    }
+
+    @Test
+    void testUpdateNotificationSettingsForPolicy() {
+        // 특정 정책에 대해 알림을 설정하는 테스트
+        Long mockUid = 123L;
+        Long policyIdx = 1L;
+        when(memberService.getAuthenticatedUid()).thenReturn(mockUid);
+
+        Map<String, Object> request = new HashMap<>();
+        request.put("notificationEnabled", true);
+        request.put("applyEndDate", new Date());
+
+        ResponseEntity<String> response = notificationController.updateNotificationSettings(policyIdx, request);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals("Notification settings updated successfully.", response.getBody());
+        verify(notificationService, times(1)).saveOrUpdateNotification(mockUid, policyIdx, true, (Date) request.get("applyEndDate"));
+    }
+
+    @Test
+    void testDeleteNotificationSettings() {
+        // 특정 정책에 대한 알림 설정을 삭제하는 테스트
+        Long mockUid = 123L;
+        Long policyIdx = 1L;
+        when(memberService.getAuthenticatedUid()).thenReturn(mockUid);
+
+        ResponseEntity<String> response = notificationController.deleteNotificationSettings(policyIdx);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals("Notification settings deleted successfully.", response.getBody());
+        verify(notificationService, times(1)).deleteNotification(mockUid, policyIdx);
+    }
+
+    @Test
+    void testGetMemberDefinedNotifications() {
+        // 사용자가 직접 설정한 알림 목록을 가져오는 테스트
+        Long mockUid = 123L;
+        when(memberService.getAuthenticatedUid()).thenReturn(mockUid);
+        List<PolicyAlarm> mockNotifications = List.of(new PolicyAlarm());
+
+        when(notificationService.getMemberNotifications(mockUid)).thenReturn(mockNotifications);
+
+        ResponseEntity<?> response = notificationController.getMemberDefinedNotifications();
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        SuccessResponse successResponse = (SuccessResponse) response.getBody();
+        assertEquals(mockNotifications, successResponse.getResponse().getData());
+    }
+
+    @Test
+    void testGetRecommendedNotifications() {
+        // 시스템에서 추천하는 알림 목록을 가져오는 테스트
+        Long mockUid = 123L;
+        when(memberService.getAuthenticatedUid()).thenReturn(mockUid);
+        List<PolicyAlarm> mockRecommendedNotifications = List.of(new PolicyAlarm());
+
+        when(notificationService.getRecommendedNotifications(mockUid)).thenReturn(mockRecommendedNotifications);
+
+        ResponseEntity<?> response = notificationController.getRecommendedNotifications();
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        SuccessResponse successResponse = (SuccessResponse) response.getBody();
+        assertEquals(mockRecommendedNotifications, successResponse.getResponse().getData());
+    }
+
+    @Test
+    void testGetNotificationDashboard() {
+        Long mockUid = 123L;
+        when(memberService.getAuthenticatedUid()).thenReturn(mockUid);
+
+        PolicyAlarm memberAlarm = new PolicyAlarm();
+        memberAlarm.setPolicyIdx(1L);
+        PolicyAlarm recommendedAlarm = new PolicyAlarm();
+        recommendedAlarm.setPolicyIdx(2L);
+
+        List<PolicyAlarm> mockMemberNotifications = List.of(memberAlarm);
+        List<PolicyAlarm> mockRecommendedNotifications = List.of(recommendedAlarm);
+        List<PolicyDetailFilter> mockRecommendedPolicies = List.of(new PolicyDetailFilter());
+
+        PolicyList mockPolicy = new PolicyList();
+        mockPolicy.setName("Test Policy");
+        mockPolicy.setApplyEndDate(new Date());
+
+        when(notificationService.getMemberNotifications(mockUid)).thenReturn(mockMemberNotifications);
+        when(notificationService.getRecommendedNotifications(mockUid)).thenReturn(mockRecommendedNotifications);
+        when(policyRecommendationService.getRecommendedPolicies(mockUid)).thenReturn(mockRecommendedPolicies);
+
+        when(policyListRepository.findById(1L)).thenReturn(Optional.of(mockPolicy));
+        when(policyListRepository.findById(2L)).thenReturn(Optional.of(mockPolicy));
+
+        ResponseEntity<Map<String, Object>> response = notificationController.getNotificationDashboard();
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        Map<String, Object> dashboard = response.getBody();
+
+        System.out.println("Dashboard: " + dashboard);
+
+        // 대시보드의 "memberNotifications" 값 확인
+        List<Map<String, Object>> memberNotifications = (List<Map<String, Object>>) dashboard.get("memberNotifications");
+        assertEquals(1, memberNotifications.size());
+        assertEquals("Test Policy", memberNotifications.get(0).get("policyName"));
+        assertEquals(mockPolicy.getApplyEndDate(), memberNotifications.get(0).get("applyEndDate"));
+
+        // 대시보드의 "recommendedNotifications" 값 확인
+        List<Map<String, Object>> recommendedNotifications = (List<Map<String, Object>>) dashboard.get("recommendedNotifications");
+        assertEquals(1, recommendedNotifications.size());
+        assertEquals("Test Policy", recommendedNotifications.get(0).get("policyName"));
+        assertEquals(mockPolicy.getApplyEndDate(), recommendedNotifications.get(0).get("applyEndDate"));
+    }
+}

--- a/src/test/java/com/chapter1/blueprint/member/service/MemberServiceTest.java
+++ b/src/test/java/com/chapter1/blueprint/member/service/MemberServiceTest.java
@@ -1,0 +1,76 @@
+package com.chapter1.blueprint.member.service;
+
+import com.chapter1.blueprint.security.util.JwtProcessor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class MemberServiceTest {
+
+    @Mock
+    private JwtProcessor jwtProcessor;
+
+    @InjectMocks
+    private MemberService memberService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testGetAuthenticatedUid_Success() {
+        SecurityContext securityContext = mock(SecurityContext.class);
+        SecurityContextHolder.setContext(securityContext);
+
+        String token = "mockToken";
+        when(securityContext.getAuthentication())
+                .thenReturn(new UsernamePasswordAuthenticationToken(null, token));
+
+        Long mockUid = 123L;
+        when(jwtProcessor.getUid(token)).thenReturn(mockUid);
+
+        Long uid = memberService.getAuthenticatedUid();
+
+        assertNotNull(uid);
+        assertEquals(mockUid, uid);
+        verify(jwtProcessor, times(1)).getUid(token);
+    }
+
+    @Test
+    void testGetAuthenticatedUid_NoAuthentication() {
+        SecurityContext securityContext = mock(SecurityContext.class);
+        SecurityContextHolder.setContext(securityContext);
+
+        when(securityContext.getAuthentication()).thenReturn(null);
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            memberService.getAuthenticatedUid();
+        });
+        assertEquals("No authentication found", exception.getMessage());
+    }
+
+    @Test
+    void testGetAuthenticatedUid_InvalidCredentials() {
+
+        SecurityContext securityContext = mock(SecurityContext.class);
+        SecurityContextHolder.setContext(securityContext);
+
+        when(securityContext.getAuthentication())
+                .thenReturn(new UsernamePasswordAuthenticationToken(null, 123)); // Invalid credentials
+
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            memberService.getAuthenticatedUid();
+        });
+        assertEquals("Invalid authentication credentials", exception.getMessage());
+    }
+}


### PR DESCRIPTION
### #️⃣ 24.11.17

### 📝 작업 내용
- notification 브랜치 머지 후 코드 작업 진행
- 맞춤형 서비스(정책, 청약)를 위한 인증을 memberId로 작성했던 코드를 모두 uid로 변경