### PR TITLE
Feat: 알림 설정 및 정책 알림 기능 구현

### DIFF
--- a/src/main/java/com/chapter1/blueprint/exception/codes/ErrorCode.java
+++ b/src/main/java/com/chapter1/blueprint/exception/codes/ErrorCode.java
@@ -19,18 +19,29 @@ public enum ErrorCode {
     // 서버(Server)
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SERVER_001", "서버 내부 에러가 발생했습니다."),
 
-    // Real Estamate Error
+    // 정책(Policy)
+    POLICY_NOT_FOUND(HttpStatus.NOT_FOUND, "POLICY_001", "해당 정책을 찾을 수 없습니다."),
+
+    // 부동산(Real Estate)
     REAL_ESTATE_NOT_FOUND(HttpStatus.NOT_FOUND, "ESTATE_001", "부동산 정보를 찾을 수 없습니다."),
     INVALID_REGION_PARAMETER(HttpStatus.BAD_REQUEST, "ESTATE_002", "잘못된 지역 정보가 입력되었습니다."),
     REAL_ESTATE_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "ESTATE_003", "부동산 정보 조회 중 오류가 발생했습니다."),
 
-    // 요청(Request 관련 에러
+    // 요청(Request 관련 에러)
     BAD_REQUEST_ERROR(HttpStatus.BAD_REQUEST, "G001", "잘못된 요청입니다."),
 
     // 이메일(Email)
     INVALID_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, "EMAIL_001", "유효하지 않은 인증 코드입니다."),
     VERIFICATION_CODE_EXPIRED(HttpStatus.BAD_REQUEST, "EMAIL_002", "인증 코드가 만료되었습니다."),
-    EMAIL_SENDING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "EMAIL_003", "이메일 전송에 실패하였습니다.");
+    EMAIL_SENDING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "EMAIL_003", "이메일 전송에 실패하였습니다."),
+    RECOMMENDED_POLICY_EMAIL_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "EMAIL_004", "추천된 정책 이메일 전송에 실패하였습니다."),
+
+    // 알림(Notification)
+    NOTIFICATION_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "NOTIFICATION_001", "알림 상태 업데이트에 실패했습니다."),
+    POLICY_ALARM_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION_002", "해당 알림 설정을 찾을 수 없습니다."),
+    NOTIFICATION_DELETION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "NOTIFICATION_003", "알림 삭제에 실패했습니다."),
+    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION_004", "알림을 찾을 수 없습니다.");
+
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/chapter1/blueprint/member/controller/NotificationController.java
+++ b/src/main/java/com/chapter1/blueprint/member/controller/NotificationController.java
@@ -48,10 +48,13 @@ public class NotificationController {
 
         notificationService.updateNotificationStatus(uid, notificationEnabled);
 
-        logger.info("Notification status updated successfully for UID: {}", uid);
+        boolean updatedNotificationStatus = notificationService.getNotificationStatus(uid);
 
-        return ResponseEntity.ok(new SuccessResponse("Notification status updated successfully."));
+        logger.info("Notification status updated successfully for UID: {} with new status: {}", uid, updatedNotificationStatus);
+
+        return ResponseEntity.ok(new SuccessResponse(Map.of("notificationEnabled", updatedNotificationStatus)));
     }
+
 
 
     @PutMapping("/{policyIdx}")

--- a/src/main/java/com/chapter1/blueprint/member/controller/NotificationController.java
+++ b/src/main/java/com/chapter1/blueprint/member/controller/NotificationController.java
@@ -36,6 +36,18 @@ public class NotificationController {
 
     private static final Logger logger = LoggerFactory.getLogger(NotificationController.class);
 
+    @GetMapping("/status")
+    public ResponseEntity<SuccessResponse> getNotificationStatus() {
+        Long uid = memberService.getAuthenticatedUid();
+        logger.info("Fetching notification status for UID: {}", uid);
+        
+        boolean notificationStatus = notificationService.getNotificationStatus(uid);
+
+        logger.info("Notification status fetched successfully for UID: {} with status: {}", uid, notificationStatus);
+
+        return ResponseEntity.ok(new SuccessResponse(Map.of("notificationEnabled", notificationStatus)));
+    }
+
     @PutMapping("/status")
     public ResponseEntity<SuccessResponse> updateNotificationStatus(@RequestBody Map<String, Object> request) {
         Long uid = memberService.getAuthenticatedUid();

--- a/src/main/java/com/chapter1/blueprint/member/domain/PolicyAlarm.java
+++ b/src/main/java/com/chapter1/blueprint/member/domain/PolicyAlarm.java
@@ -36,4 +36,7 @@ public class PolicyAlarm {
 
     @Column(name = "apply_end_date")
     private Date applyEndDate;
+
+    @Column(name = "is_read")
+    private Boolean isRead = false;
 }

--- a/src/main/java/com/chapter1/blueprint/member/domain/PolicyAlarmType.java
+++ b/src/main/java/com/chapter1/blueprint/member/domain/PolicyAlarmType.java
@@ -1,0 +1,16 @@
+package com.chapter1.blueprint.member.domain;
+
+public enum PolicyAlarmType {
+    RECOMMENDED("RECOMMENDED"),
+    MEMBER_DEFINED("MEMBER_DEFINED");
+
+    private final String type;
+
+    PolicyAlarmType(String type) {
+        this.type = type;
+    }
+
+    public String getType() {
+        return type;
+    }
+}

--- a/src/main/java/com/chapter1/blueprint/member/repository/PolicyAlarmRepository.java
+++ b/src/main/java/com/chapter1/blueprint/member/repository/PolicyAlarmRepository.java
@@ -23,6 +23,8 @@ public interface PolicyAlarmRepository extends JpaRepository<PolicyAlarm, Long> 
 
     List<PolicyAlarm> findByUidAndAlarmType(Long uid, String alarmType);
 
+    List<PolicyAlarm> findAllByNotificationEnabled(Boolean notificationEnabled);
+
     @Query("SELECT p FROM PolicyAlarm p WHERE p.notificationEnabled = true AND p.applyEndDate <= :applyEndDate")
     List<PolicyAlarm> findEnabledNotificationsBeforeDeadline(@Param("applyEndDate") Date applyEndDate);
 

--- a/src/main/java/com/chapter1/blueprint/member/service/MemberService.java
+++ b/src/main/java/com/chapter1/blueprint/member/service/MemberService.java
@@ -9,9 +9,7 @@ import com.chapter1.blueprint.member.domain.dto.PasswordDTO;
 import com.chapter1.blueprint.member.domain.dto.ProfileInfoDTO;
 import com.chapter1.blueprint.member.dto.MemberDTO;
 import com.chapter1.blueprint.member.repository.MemberRepository;
-import com.chapter1.blueprint.member.repository.PolicyAlarmRepository;
-import com.chapter1.blueprint.policy.domain.dto.PolicyListDTO;
-import com.chapter1.blueprint.policy.repository.PolicyListRepository;
+
 import com.chapter1.blueprint.security.util.JwtProcessor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -55,14 +53,10 @@ public class MemberService {
             }
 
             String token = (String) authentication.getCredentials();
-            log.error("token completed: {}", token);
 
-            // Bearer 접두어 제거
             if (token.startsWith("Bearer ")) {
-                token = token.substring(7);  // "Bearer " 이후의 실제 토큰 값만 추출
+                token = token.substring(7);
             }
-
-            log.error("Token after removing Bearer prefix: {}", token);
 
             return jwtProcessor.getUid(token);
         } catch (Exception e) {

--- a/src/main/java/com/chapter1/blueprint/member/service/NotificationService.java
+++ b/src/main/java/com/chapter1/blueprint/member/service/NotificationService.java
@@ -31,6 +31,17 @@ public class NotificationService {
 
     private static final Logger logger = LoggerFactory.getLogger(NotificationService.class);
 
+    @Transactional(readOnly = true)
+    public boolean getNotificationStatus(Long uid) {
+        logger.info("Fetching notification status for UID: {}", uid);
+        Member member = memberRepository.findById(uid)
+                .orElseThrow(() -> new ErrorCodeException(ErrorCode.MEMBER_NOT_FOUND));
+
+        logger.info("Notification status for UID {}: {}", uid, member.getNotificationStatus());
+        return member.getNotificationStatus(); // DB에 저장된 notificationStatus 반환
+    }
+
+
     @Transactional
     public void updateNotificationStatus(Long uid, boolean enabled) {
         logger.info("Updating notification status for UID: {}", uid);

--- a/src/main/java/com/chapter1/blueprint/member/service/NotificationService.java
+++ b/src/main/java/com/chapter1/blueprint/member/service/NotificationService.java
@@ -1,15 +1,23 @@
 package com.chapter1.blueprint.member.service;
 
+import com.chapter1.blueprint.exception.codes.ErrorCode;
+import com.chapter1.blueprint.exception.codes.ErrorCodeException;
+import com.chapter1.blueprint.member.domain.Member;
 import com.chapter1.blueprint.member.domain.PolicyAlarm;
+import com.chapter1.blueprint.member.domain.PolicyAlarmType;
+import com.chapter1.blueprint.member.repository.MemberRepository;
 import com.chapter1.blueprint.member.repository.PolicyAlarmRepository;
+import com.chapter1.blueprint.policy.domain.PolicyList;
+import com.chapter1.blueprint.policy.repository.PolicyListRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Date;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -18,66 +26,98 @@ import java.util.stream.Collectors;
 public class NotificationService {
 
     private final PolicyAlarmRepository policyAlarmRepository;
+    private final MemberRepository memberRepository;
+    private final PolicyListRepository policyListRepository;
 
     private static final Logger logger = LoggerFactory.getLogger(NotificationService.class);
 
+    @Transactional
     public void updateNotificationStatus(Long uid, boolean enabled) {
-        log.info("Step 5 - Starting updateNotificationStatus for UID: {}", uid);
+        logger.info("Updating notification status for UID: {}", uid);
 
         try {
-            List<PolicyAlarm> alarms = policyAlarmRepository.findByUid(uid);
-            log.info("Step 6 - Found {} PolicyAlarms for UID: {}", alarms.size(), uid);
+            // 1. Member 엔티티 업데이트
+            Member member = memberRepository.findById(uid)
+                    .orElseThrow(() -> new ErrorCodeException(ErrorCode.MEMBER_NOT_FOUND));
+            member.setNotificationStatus(enabled);
+            memberRepository.save(member);
+            logger.info("Updated Member.notificationStatus for UID: {}", uid);
+
+            // 2. PolicyAlarm 엔티티 업데이트
+            List<PolicyAlarm> alarms = policyAlarmRepository.findByUidAndAlarmType(uid, PolicyAlarmType.RECOMMENDED.getType());
+            logger.info("Found {} RECOMMENDED PolicyAlarms for UID: {}", alarms.size(), uid);
 
             if (alarms.isEmpty()) {
-                log.info("Step 7a - No existing PolicyAlarm. Creating new one for UID: {}", uid);
+                logger.info("No existing RECOMMENDED PolicyAlarm. Creating a new one for UID: {}", uid);
                 PolicyAlarm newAlarm = PolicyAlarm.builder()
                         .uid(uid)
                         .notificationEnabled(enabled)
-                        .policyIdx(0L)  // 또는 적절한 기본값
-                        .alarmType("MEMBER_DEFINED")  // 알람 타입 설정
+                        .policyIdx(0L)
+                        .alarmType(PolicyAlarmType.RECOMMENDED.getType())
                         .build();
                 policyAlarmRepository.save(newAlarm);
-                log.info("Step 8a - Successfully created new PolicyAlarm");
+                logger.info("Created new RECOMMENDED PolicyAlarm for UID: {}", uid);
             } else {
-                log.info("Step 7b - Updating {} existing PolicyAlarms", alarms.size());
-                for (PolicyAlarm alarm : alarms) {
-                    alarm.setNotificationEnabled(enabled);
-                }
+                logger.info("Updating {} RECOMMENDED PolicyAlarms for UID: {}", alarms.size(), uid);
+                alarms.forEach(alarm -> alarm.setNotificationEnabled(enabled));
                 policyAlarmRepository.saveAll(alarms);
-                log.info("Step 8b - Successfully updated existing PolicyAlarms");
+                logger.info("Updated existing RECOMMENDED PolicyAlarms for UID: {}", uid);
+            }
+        } catch (ErrorCodeException e) {
+            logger.error("Error while updating notification status for UID: {}", uid, e);
+            throw e;
+        } catch (Exception e) {
+            logger.error("Unexpected error while updating notification status for UID: {}", uid, e);
+            throw new ErrorCodeException(ErrorCode.NOTIFICATION_UPDATE_FAILED);
+        }
+    }
+
+    @Transactional
+    public void saveOrUpdateNotification(Long uid, Long policyIdx, boolean notificationEnabled) {
+        try {
+            PolicyAlarm existingAlarm = policyAlarmRepository.findByUidAndPolicyIdx(uid, policyIdx);
+
+            if (existingAlarm == null) {
+                logger.info("Creating new MEMBER_DEFINED PolicyAlarm for UID: {}, PolicyIdx: {}", uid, policyIdx);
+                PolicyAlarm newAlarm = PolicyAlarm.builder()
+                        .uid(uid)
+                        .policyIdx(policyIdx)
+                        .notificationEnabled(notificationEnabled)
+                        .alarmType(PolicyAlarmType.MEMBER_DEFINED.getType())
+                        .build();
+                policyAlarmRepository.save(newAlarm);
+            } else {
+                logger.info("Updating MEMBER_DEFINED PolicyAlarm for UID: {}, PolicyIdx: {}", uid, policyIdx);
+                existingAlarm.setNotificationEnabled(notificationEnabled);
+                existingAlarm.setAlarmType(PolicyAlarmType.MEMBER_DEFINED.getType());
+                policyAlarmRepository.save(existingAlarm);
             }
         } catch (Exception e) {
-            log.error("Error in updateNotificationStatus", e);
-            throw e;
+            logger.error("Unexpected error while saving or updating MEMBER_DEFINED notification for UID: {}, PolicyIdx: {}", uid, policyIdx, e);
+            throw new ErrorCodeException(ErrorCode.NOTIFICATION_UPDATE_FAILED);
         }
     }
 
-    public void saveOrUpdateNotification(Long uid, Long policyIdx, boolean notificationEnabled, Date applyEndDate) {
-        PolicyAlarm alarm = policyAlarmRepository.findByUidAndPolicyIdx(uid, policyIdx);
 
-        if (alarm == null) {
-            alarm = new PolicyAlarm();
-            alarm.setUid(uid);
-            alarm.setPolicyIdx(policyIdx);
-            alarm.setNotificationEnabled(notificationEnabled);
-            alarm.setApplyEndDate(applyEndDate);
-        } else {
-            alarm.setNotificationEnabled(notificationEnabled);
-            alarm.setApplyEndDate(applyEndDate);
-        }
-
-        policyAlarmRepository.save(alarm);
-    }
-
+    @Transactional
     public void deleteNotification(Long uid, Long policyIdx) {
-        PolicyAlarm alarm = policyAlarmRepository.findByUidAndPolicyIdx(uid, policyIdx);
+        try {
+            PolicyAlarm alarm = policyAlarmRepository.findByUidAndPolicyIdx(uid, policyIdx);
+            if (alarm == null) {
+                throw new ErrorCodeException(ErrorCode.POLICY_ALARM_NOT_FOUND);
+            }
 
-        if (alarm == null) {
-            throw new IllegalArgumentException("Notification not found for uid: " + uid + ", policyIdx: " + policyIdx);
+            policyAlarmRepository.delete(alarm);
+            logger.info("Notification deleted for UID: {}, PolicyIdx: {}", uid, policyIdx);
+        } catch (ErrorCodeException e) {
+            logger.error("Error during deletion of notification for UID: {}, PolicyIdx: {}", uid, policyIdx, e);
+            throw e;
+        } catch (Exception e) {
+            logger.error("Unexpected error during notification deletion for UID: {}, PolicyIdx: {}", uid, policyIdx, e);
+            throw new ErrorCodeException(ErrorCode.NOTIFICATION_DELETION_FAILED);
         }
-
-        policyAlarmRepository.delete(alarm);
     }
+
 
     public List<PolicyAlarm> getMemberNotifications(Long uid) {
         return policyAlarmRepository.findByUidAndAlarmType(uid, "MEMBER_DEFINED")
@@ -91,5 +131,18 @@ public class NotificationService {
                 .stream()
                 .filter(alarm -> alarm.getApplyEndDate() != null)
                 .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void markNotificationAsRead(Long uid, Long policyIdx) {
+        PolicyAlarm alarm = policyAlarmRepository.findByUidAndPolicyIdx(uid, policyIdx);
+        if (alarm == null) {
+            logger.error("Notification not found for UID: {}, PolicyIdx: {}", uid, policyIdx);
+            throw new ErrorCodeException(ErrorCode.NOTIFICATION_NOT_FOUND);
+        }
+        logger.info("Fetched PolicyAlarm: {}", alarm);
+
+        alarm.setIsRead(true);
+        policyAlarmRepository.save(alarm);
     }
 }

--- a/src/test/java/com/chapter1/blueprint/member/controller/NotificationControllerTest.java
+++ b/src/test/java/com/chapter1/blueprint/member/controller/NotificationControllerTest.java
@@ -52,7 +52,7 @@ class NotificationControllerTest {
         Map<String, Object> request = new HashMap<>();
         request.put("notificationEnabled", true);
 
-        ResponseEntity<String> response = notificationController.updateNotificationStatus(request);
+        ResponseEntity<SuccessResponse> response = notificationController.updateNotificationStatus(request);
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals("Notification status updated successfully.", response.getBody());
@@ -68,7 +68,7 @@ class NotificationControllerTest {
         Map<String, Object> request = new HashMap<>();
         request.put("notificationEnabled", false);
 
-        ResponseEntity<String> response = notificationController.updateNotificationStatus(request);
+        ResponseEntity<SuccessResponse> response = notificationController.updateNotificationStatus(request);
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals("Notification status updated successfully.", response.getBody());
@@ -86,11 +86,11 @@ class NotificationControllerTest {
         request.put("notificationEnabled", true);
         request.put("applyEndDate", new Date());
 
-        ResponseEntity<String> response = notificationController.updateNotificationSettings(policyIdx, request);
+        ResponseEntity<SuccessResponse> response = notificationController.updateNotificationSettings(policyIdx, request);
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals("Notification settings updated successfully.", response.getBody());
-        verify(notificationService, times(1)).saveOrUpdateNotification(mockUid, policyIdx, true, (Date) request.get("applyEndDate"));
+        verify(notificationService, times(1)).saveOrUpdateNotification(mockUid, policyIdx, true);
     }
 
     @Test
@@ -164,10 +164,10 @@ class NotificationControllerTest {
         when(policyListRepository.findById(1L)).thenReturn(Optional.of(mockPolicy));
         when(policyListRepository.findById(2L)).thenReturn(Optional.of(mockPolicy));
 
-        ResponseEntity<Map<String, Object>> response = notificationController.getNotificationDashboard();
+        ResponseEntity<SuccessResponse> response = notificationController.getNotificationDashboard();
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
-        Map<String, Object> dashboard = response.getBody();
+        Map<String, Object> dashboard = (Map<String, Object>) response.getBody();
 
         System.out.println("Dashboard: " + dashboard);
 


### PR DESCRIPTION
### #️⃣ 24.

### 📝 작업 내용
. **알림 설정 On/Off 기능**
- `notificationEnabled` 필드를 사용하여 DB에 알림 상태 저장 및 관리
- `/member/notification/status` API 구현:
  - 알림 상태 조회(GET) 및 업데이트(PUT) 기능 추가
  - 사용자의 알림 설정 상태를 DB와 동기화

2. **PolicyAlarm 테이블 연동**
- 사용자 설정 정책 저장 및 삭제 기능 추가:
  - 알림 추가: `/member/notification/{policyIdx}` API를 통해 정책 알림 추가(PUT)
  - 알림 삭제: `/member/notification/{policyIdx}` API를 통해 정책 알림 삭제(DELETE)
- PolicyAlarm 엔티티에 `isRead` 필드 추가:
  - 읽음 상태 업데이트 기능 구현(`/member/notification/read/{policyIdx}` API)

3. **추천 정책 및 알림 데이터 제공**
- 추천 정책 실시간 생성 로직 추가 (`PolicyRecommendationService`):
  - 사용자 조건에 따른 추천 정책 생성 및 관리
- `/member/notification/dashboard` API 개선:
  - 사용자 설정 알림과 추천된 알림 데이터를 통합하여 제공
  - 읽음 상태(`isRead`)와 날짜 형식을 `yyyy-MM-dd`로 포맷팅하여 제공
- 사용자 설정 알림 및 추천된 알림 API 구현:
  - `/member/notification/list/member` API로 사용자 설정 알림 제공
  - `/member/notification/list/recommended` API로 추천된 알림 제공

4. **Push 알림 및 마감일 알림 스케줄링**
- `/notifications/push` API 구현:
  - `applyEndDate` 기준으로 마감 하루 전 메시지 생성
  - 정책 이름 및 마감일 기반 메시지 제공:
    - 마감 하루 전 메시지: `"정책 이름 마감 하루 전입니다"`.
    - 마감 3일 전 이메일 발송 메시지 추가
  - 날짜 포맷: `DateTimeFormatter.ofPattern("yyyy-MM-dd")` 적용.
- 마감일 알림 스케줄러 구현:
  - 사용자 설정 정책(user_selected) 및 추천 정책(system_recommended)을 분리하여 처리
  - 마감일 기준 3일 전 이메일 자동 발송 로직 추가

5. **테스트 및 안정성 강화**
- Postman을 통해 모든 API 테스트 완료:
  - 알림 상태 조회(GET), 수정(PUT), 삭제(DELETE), 읽음 처리 기능 정상 동작 확인
  - 에러 처리 및 로깅 정상 동작 확인
